### PR TITLE
Added ability to store keys in the environment variables

### DIFF
--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -152,7 +152,7 @@ defmodule Cloak.AES.CTR do
   end
 
   defp get_key_value(key_config) do
-    case key_config do
+    case key_config.key do
       {:system, env_var} ->
         System.get_env(env_var)
       


### PR DESCRIPTION
It is a good practice to store keys, secret tokens in the environment variables. Then they are never committed into repository, and this is de facto standard in environments such as Heroku.

This PR adds possibility to define that keys are stored in the environment using  `{:system, something}` syntax that is often used by the Phoenix Framework.