### PR TITLE
Update examples to reflect the remotion of Cloak.Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,23 @@ end
 
 # in your model
 defmodule MyApp.Model do
-  use Ecto.Model
-  use Cloak.Model, :encryption_version
+  use Ecto.Schema
 
   schema "models" do
     field :secret_key, Cloak.EncryptedBinaryField
     field :encryption_version, :binary
   end
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(secret_key), ~w(encryption_version))
+    |> put_change(:encryption_version, Cloak.version)
+  end
 end
 
 # Query
 MyApp.Repo.one(MyApp.Model)
-# => %MyApp.Model{field_name: "Decrypted value", encryption_version: <<"AES", 1>>}
+# => %MyApp.Model{secret_key: "Decrypted value", encryption_version: <<"AES", 1>>}
 ```
 
 ## Installation

--- a/lib/cloak.ex
+++ b/lib/cloak.ex
@@ -176,7 +176,7 @@ defmodule Cloak do
   Returns the default cipher module's tag combined with the result of that
   cipher's `version/0` function.
 
-  It is used by `Cloak.Model` to record which cipher was used to encrypt a row
+  It is used in changesets to record which cipher was used to encrypt a row
   in a database table. This is very useful when migrating to a new cipher or new
   encryption key, because you'd be able to query your database to find records
   that need to be migrated.

--- a/lib/cloak/ciphers/behaviour.ex
+++ b/lib/cloak/ciphers/behaviour.ex
@@ -6,7 +6,7 @@ defmodule Cloak.Cipher do
   ## Example
 
   Here's a sample custom cipher that adds "Hello, " to the start of every
-  ciphertext, and removes it on decryption. 
+  ciphertext, and removes it on decryption.
 
       defmodule MyCustomCipher do
         @behaviour Cloak.Cipher
@@ -24,14 +24,14 @@ defmodule Cloak.Cipher do
         end
       end
 
-  As long as you implement the 3 callbacks below, everything should work 
-  smoothly. 
+  As long as you implement the 3 callbacks below, everything should work
+  smoothly.
 
   ## Configuration
 
   Your custom cipher will be responsible for reading any custom configuration
-  that it requires from the `:cloak` application configuration. 
-  
+  that it requires from the `:cloak` application configuration.
+
   For example, suppose we wanted to make the word "Hello" in the custom cipher
   above configurable. We could add it to the `config.exs`:
 
@@ -75,13 +75,11 @@ defmodule Cloak.Cipher do
 
   @doc """
   Must return a string representing the default settings of your module as it is
-  currently configured. 
-  
-  This will be used by `Cloak.version/0` to generate a unique tag, which can 
+  currently configured.
+
+  This will be used by `Cloak.version/0` to generate a unique tag, which can
   then be stored on each database table row to track which encryption
   configuration it is currently encrypted with.
-
-  See `Cloak.Model` for more details.
   """
   defcallback version :: String.t
 end


### PR DESCRIPTION
This is needed in order to prepare the users for the upcoming Ecto version 2.0, and because the Cloak.Model was removed.

Related commit: https://github.com/danielberkompas/cloak/commit/431289bc52546edc324e3a643ce42d7a6c5bbd6f