### PR TITLE
Bumped ecto dependency to ~> 1.1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Cloak.Mixfile do
 
   defp deps do
     [{:poison, ">= 1.5.0"},
-     {:ecto, ">= 1.0.0"},
+     {:ecto, "~> 1.1.2"},
      {:ex_doc, "~> 0.9", only: :docs},
      {:inch_ex, only: :docs}
    ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "1.0.3"},
+%{"decimal": {:hex, :decimal, "1.1.1"},
+  "ecto": {:hex, :ecto, "1.1.5"},
   "ex_doc": {:hex, :ex_doc, "0.9.0"},
   "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "poison": {:hex, :poison, "1.5.0"},
+  "poison": {:hex, :poison, "1.5.2"},
   "poolboy": {:hex, :poolboy, "1.5.1"}}


### PR DESCRIPTION
Currently dependency on Ecto is defined as >= 1.0.0. It prevents cloak from working with newer versions of phoenix.