### PR TITLE
Decode AES environment variable keys from base64

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,5 +5,6 @@ config :cloak, Cloak.AES.CTR,
   default: true,
   keys: [
     %{tag: <<1>>, key: :base64.decode("3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE="), default: true},
-    %{tag: <<2>>, key: :base64.decode("iutsyenD9K2psbQNIvdf/UTBYrFH1ONJlQUpQ6nRoAw="), default: false}
+    %{tag: <<2>>, key: :base64.decode("iutsyenD9K2psbQNIvdf/UTBYrFH1ONJlQUpQ6nRoAw="), default: false},
+    %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false}
   ]

--- a/test/cloak/ciphers/aes_ctr_test.exs
+++ b/test/cloak/ciphers/aes_ctr_test.exs
@@ -18,6 +18,12 @@ defmodule Cloak.AES.CTRTest do
     assert String.length(ciphertext) > 0
   end
 
+  test ".encrypt can encrypt a value using an environment variable as key" do
+    System.put_env("CLOAK_THIRD_KEY", "NhsNVkstdaUiXIh6fFZaRu+O6gK/p9C9LKJr3kkEWNA=")
+
+    assert encrypt("value", <<3>>) != "value"
+  end
+
   test ".decrypt can decrypt a value" do
     assert encrypt("value") |> decrypt == "value"
   end


### PR DESCRIPTION
This is needed because the user will probably store the keys encoded as base64 when using environment variables.

This also adds a basic error report when the expected key is missing or is not a valid base64 string.

Closes #9