### PR TITLE
Fix validation bug in cloak.migrate

### DIFF
--- a/lib/mix/tasks/cloak.migrate.ex
+++ b/lib/mix/tasks/cloak.migrate.ex
@@ -97,6 +97,9 @@ defmodule Mix.Tasks.Cloak.Migrate do
     """
   end
 
+  defp validate!(_repo, _models) do
+  end
+
   defp migrate({model, field}, repo) do
     info "--- Migrating #{inspect model.__struct__} Model ---"
     ids = ids_for({model, field}, repo)


### PR DESCRIPTION
`validate!` was never working because when the data was valid, there was
no matching function clause. Added an empty clause for the valid case.