### PR TITLE
Rely on configuration at runtime

### DIFF
--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -3,7 +3,7 @@ defmodule Cloak.Config do
 
   def all do
     Enum.reject Application.get_all_env(:cloak), fn({key, _}) ->
-      key == :migration
+      key in [:migration, :included_applications]
     end
   end
 

--- a/lib/ecto/encrypted_field.ex
+++ b/lib/ecto/encrypted_field.ex
@@ -3,8 +3,6 @@ defmodule Cloak.EncryptedField do
 
   defmacro __using__(_) do
     quote do
-      alias Cloak.Encryptable
-
       @doc false
       def type, do: :binary
 
@@ -15,8 +13,8 @@ defmodule Cloak.EncryptedField do
 
       @doc false
       def dump(value) do
-        value = value 
-                |> before_encrypt 
+        value = value
+                |> before_encrypt
                 |> Cloak.encrypt
 
         {:ok, value}


### PR DESCRIPTION
This will prevent Cloak from needing to be recompiled when you change
keys.