### PR TITLE
clean up compile warnings under Elixir 1.4

### DIFF
--- a/lib/cloak.ex
+++ b/lib/cloak.ex
@@ -134,7 +134,7 @@ defmodule Cloak do
       <<"AES", ...>>
   """
   def encrypt(plaintext) do
-    tag <> cipher.encrypt(plaintext)
+    tag() <> cipher().encrypt(plaintext)
   end
 
   @doc """
@@ -189,7 +189,7 @@ defmodule Cloak do
   that need to be migrated.
   """
   def version do
-    tag <> cipher.version
+    tag() <> cipher().version
   end
 
   defp cipher do

--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -102,7 +102,7 @@ defmodule Cloak.AES.CTR do
   """
   def encrypt(plaintext, key_tag \\ nil) do
     iv = :crypto.strong_rand_bytes(16)
-    key = get_key_config(key_tag) || default_key
+    key = get_key_config(key_tag) || default_key()
     state = :crypto.stream_init(:aes_ctr, get_key_value(key), iv)
 
     {_state, ciphertext} = :crypto.stream_encrypt(state, to_string(plaintext))
@@ -138,11 +138,11 @@ defmodule Cloak.AES.CTR do
   current default key.
   """
   def version do
-    default_key.tag
+    default_key().tag
   end
 
   defp get_key_config(tag) do
-    Enum.find(config[:keys], fn(key) -> key.tag == tag end)
+    Enum.find(config()[:keys], fn(key) -> key.tag == tag end)
   end
 
   defp get_key_value(key_config) do
@@ -174,6 +174,6 @@ defmodule Cloak.AES.CTR do
   end
 
   defp default_key do
-    Enum.find config[:keys], fn(key) -> key.default end
+    Enum.find config()[:keys], fn(key) -> key.default end
   end
 end

--- a/lib/cloak/ciphers/behaviour.ex
+++ b/lib/cloak/ciphers/behaviour.ex
@@ -60,18 +60,18 @@ defmodule Cloak.Cipher do
       end
   """
 
-  use Behaviour
+#  use Behaviour
 
   @doc """
   Encrypt a value. Your function should include any information it will need for
   decryption with the output.
   """
-  defcallback encrypt(any) :: String.t
+  @callback encrypt(any) :: String.t
 
   @doc """
   Decrypt a value.
   """
-  defcallback decrypt(String.t) :: String.t
+  @callback decrypt(String.t) :: String.t
 
   @doc """
   Must return a string representing the default settings of your module as it is
@@ -81,5 +81,5 @@ defmodule Cloak.Cipher do
   then be stored on each database table row to track which encryption
   configuration it is currently encrypted with.
   """
-  defcallback version :: String.t
+  @callback version :: String.t
 end

--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -8,7 +8,7 @@ defmodule Cloak.Config do
   end
 
   def default_cipher do
-    cipher = Enum.find all, fn({_cipher, opts}) ->
+    cipher = Enum.find all(), fn({_cipher, opts}) ->
       opts[:default] == true
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule Cloak.Mixfile do
      start_permanent: Mix.env == :prod,
      source_url: "https://github.com/danielberkompas/cloak",
      description: "Encrypted fields for Ecto.",
-     package: package,
-     deps: deps,
-     docs: docs]
+     package: package(),
+     deps: deps(),
+     docs: docs()]
   end
 
   def application do

--- a/test/cloak_test.exs
+++ b/test/cloak_test.exs
@@ -20,6 +20,6 @@ defmodule CloakTest do
   end
 
   test ".version returns the default cipher tag joined with the cipher.version" do
-    assert <<"AES", 1>> = version
+    assert <<"AES", 1>> = version()
   end
 end

--- a/test/mix/cloak.migrate_test.exs
+++ b/test/mix/cloak.migrate_test.exs
@@ -23,12 +23,12 @@ defmodule Cloak.MigrateTest do
     end
 
     def update!(changeset) do
-      send self, {:changeset, changeset}
+      send self(), {:changeset, changeset}
     end
   end
 
   setup do
-    Logger.disable(self)
+    Logger.disable( self() )
     :ok
   end
 
@@ -39,7 +39,7 @@ defmodule Cloak.MigrateTest do
       "-f", "encryption_version"
     ])
 
-    assert_changed_version
+    assert_changed_version()
   end
 
   test "uses cloak configuration if present" do
@@ -50,7 +50,7 @@ defmodule Cloak.MigrateTest do
 
     run("cloak.migrate", [])
 
-    assert_changed_version
+    assert_changed_version()
   end
 
   defp assert_changed_version do


### PR DESCRIPTION
I've cleaned up the various compile warnings in Cloak under Elixir 1.4.

The biggest change was to lib/cloak/ciphers.behaviour.ex, where I switched it from the deprecated "use Behaviour" to using @callback definitions. This doesn't change any behaviour.