### PR TITLE
Add `prepare_changes` example to module doc for use with ecto 2.0

### DIFF
--- a/lib/ecto/sha_256_field.ex
+++ b/lib/ecto/sha_256_field.ex
@@ -4,12 +4,13 @@ defmodule Cloak.SHA256Field do
 
   ## Usage
 
-  By storing a hash of a field's value, you can then query on it, because SHA256
-  is deterministic and always results in the same value, whereas secure
-  encryption does not. Be warned, however, that this will expose fields which
-  have the same value, because they will contain the same hash.
+  By storing a hash of a field's value, you can then query on it as a proxy 
+  for the encrypted field because SHA256 is deterministic and always results 
+  in the same value, whereas secure encryption does not. Be warned, however, 
+  that this will expose fields which have the same value, because they will 
+  contain the same hash.
 
-  You should create the field with the type `:binary`. It can then be added to
+  You should create the hash field with the type `:binary`. It can then be added to
   your `schema` definition like this:
 
       schema "table" do
@@ -17,7 +18,7 @@ defmodule Cloak.SHA256Field do
         field :field_name_hash, Cloak.SHA256Field
       end
 
-  You'll also want to add `before_insert/1` and `before_update/1` callbacks to
+  In versions of Ecto < 2.0 you'll also want to add `before_insert/1` and `before_update/1` callbacks to
   ensure that the field is set every time that `:field_name` changes.
 
       before_insert :set_field_name_hash
@@ -26,6 +27,22 @@ defmodule Cloak.SHA256Field do
       defp set_field_name_hash(changeset) do
         put_change(changeset, :field_name_hash, get_field(changeset, :field_name))
       end
+      
+  In Ecto versions > 2.0 callbacks have been removed so you will need to use the `prepare_changes/2` function
+  on the changeset to ensure that the fields stay in sync every time `:field_name` changes.
+  
+      def changeset(struct, params \\ %{}) do
+        struct
+        |> cast(params, [:field_name, :field_name_hash])
+        |> prepare_changes(fn changeset ->
+            changeset
+            |> put_change(:field_name_hash, get_field(changeset, :field_name))
+           end)
+      end
+      
+  You should then be able to query the Repo using the `:field_name_hash` in any place you would typically query by `:field_name`.
+  
+      user = Repo.get_by(User, field_name_hash: "query")
   """
 
   @doc false


### PR DESCRIPTION
A similar strategy worked for me in querying a hashed field for identifying users by email address while keeping email addresses encrypted.  I'm happy to make changes if this isn't idiomatic.