### PR TITLE
Allow to specify static IV at configuration

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,5 +6,6 @@ config :cloak, Cloak.AES.CTR,
   keys: [
     %{tag: <<1>>, key: :base64.decode("3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE="), default: true},
     %{tag: <<2>>, key: :base64.decode("iutsyenD9K2psbQNIvdf/UTBYrFH1ONJlQUpQ6nRoAw="), default: false},
-    %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false}
+    %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false},
+    %{tag: <<4>>, key: :base64.decode("F0eNREprpBo2X8GJ7X1GXoMzo3CCvZbYcxH/Y03EjQc="), iv: {:system, "CLOAK_FOURTH_IV"}, default: false}
   ]

--- a/test/cloak/ciphers/aes_ctr_test.exs
+++ b/test/cloak/ciphers/aes_ctr_test.exs
@@ -24,11 +24,25 @@ defmodule Cloak.AES.CTRTest do
     assert encrypt("value", <<3>>) != "value"
   end
 
+  test ".encrypt returns ciphertext using specified iv" do
+    System.put_env("CLOAK_FOURTH_IV", "V3dNbozwXkLjp1nhT5BxyA==")
+
+    assert <<4, iv::binary-16, _ciphertext1::binary>> = encrypt("value", <<4>>)
+
+    assert iv == System.get_env("CLOAK_FOURTH_IV") |> Base.decode64!
+  end
+
   test ".decrypt can decrypt a value" do
     assert encrypt("value") |> decrypt == "value"
   end
 
   test ".decrypt can decrypt a value encrypted with a non-default key" do
     assert encrypt("value", <<2>>) |> decrypt == "value"
+  end
+
+  test ".decrypt can decrypt a value using specified iv" do
+    System.put_env("CLOAK_FOURTH_IV", "V3dNbozwXkLjp1nhT5BxyA==")
+
+    assert encrypt("value", <<4>>) |> decrypt == "value"
   end
 end


### PR DESCRIPTION
This changes allows to specify IV at configuration time.  When IV random, it not possible to query database by encrypted value. 