### PR TITLE
Allow multiple concurrent ciphers to encrypt

### DIFF
--- a/lib/cloak.ex
+++ b/lib/cloak.ex
@@ -109,7 +109,7 @@ defmodule Cloak do
   """
 
   @doc """
-  Encrypt a value using the default cipher module.
+  Encrypt a value using the cipher module associated with the tag.
 
   The `:tag` of the cipher will be prepended to the output. So, if the cipher
   was `Cloak.AES.CTR`, and the tag was "AES", the output would be in this
@@ -128,15 +128,22 @@ defmodule Cloak do
 
   - `plaintext` - The value to be encrypted.
 
-  ### Example
+  ### Optional Parameters
 
+  - `tag` - The tag of the cipher to use for encryption. If omitted,
+    will default to the default cipher.
+
+  ### Example
       Cloak.encrypt("Hello, World!")
       <<"AES", ...>>
+
+      Cloak.encrypt("Hello, World!", "AES")
+      <<"AES", ...>>
   """
-  def encrypt(plaintext) do
+  def encrypt(plaintext, tag \\ nil)
+  def encrypt(plaintext, nil) do
     default_tag() <> default_cipher().encrypt(plaintext)
   end
-
   def encrypt(plaintext, tag) do
     tag <> cipher(tag).encrypt(plaintext)
   end
@@ -199,11 +206,13 @@ defmodule Cloak do
     default_tag() <> default_cipher().version
   end
 
+  @spec default_cipher() :: module
   defp default_cipher do
     {cipher, _config} = Cloak.Config.default_cipher()
     cipher
   end
 
+  @spec default_tag() :: String.t
   defp default_tag do
     {_cipher, config} = Cloak.Config.default_cipher()
     config[:tag]
@@ -211,9 +220,10 @@ defmodule Cloak do
 
   @spec version(String.t) :: String.t
   def version(tag) do
-    tag <> cipher(tag).version
+    tag <> cipher(tag).version()
   end
 
+  @spec cipher(String.t) :: module
   defp cipher(tag) do
     {cipher, _config} = Cloak.Config.cipher(tag)
     cipher

--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -112,8 +112,8 @@ defmodule Cloak.AES.CTR do
   """
   def encrypt(plaintext, key_tag \\ nil) do
     iv = :crypto.strong_rand_bytes(16)
-    key = Cloak.Util.config(__MODULE__, key_tag) || default_key()
-    state = :crypto.stream_init(:aes_ctr, Cloak.Util.key_value(key), iv)
+    key = Cloak.Ciphers.Util.config(__MODULE__, key_tag) || default_key()
+    state = :crypto.stream_init(:aes_ctr, Cloak.Ciphers.Util.key_value(key), iv)
 
     {_state, ciphertext} = :crypto.stream_encrypt(state, to_string(plaintext))
     key.tag <> iv <> ciphertext
@@ -136,8 +136,8 @@ defmodule Cloak.AES.CTR do
       "Hello"
   """
   def decrypt(<<key_tag::binary-1, iv::binary-16, ciphertext::binary>> = _ciphertext) do
-    key = Cloak.Util.config(__MODULE__, key_tag)
-    state = :crypto.stream_init(:aes_ctr, Cloak.Util.key_value(key), iv)
+    key = Cloak.Ciphers.Util.config(__MODULE__, key_tag)
+    state = :crypto.stream_init(:aes_ctr, Cloak.Ciphers.Util.key_value(key), iv)
 
     {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
     plaintext
@@ -152,7 +152,7 @@ defmodule Cloak.AES.CTR do
   end
 
   defp default_key do
-    Cloak.Util.default_key(__MODULE__)
+    Cloak.Ciphers.Util.default_key(__MODULE__)
   end
 
 end

--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -1,12 +1,22 @@
 defmodule Cloak.Config do
   @moduledoc false
 
+  @spec all() :: Keyword.t
   def all do
     Enum.reject Application.get_all_env(:cloak), fn({key, _}) ->
       key in [:migration, :included_applications]
     end
   end
 
+  @spec cipher(String.t) :: Keyword.t
+  def cipher(tag) do
+    # TODO Should we throw here if we can't find?
+    Enum.find all(), fn({_cipher, opts}) ->
+      opts[:tag] == tag
+    end
+  end
+
+  @spec default_cipher() :: Keyword.t
   def default_cipher do
     cipher = Enum.find all(), fn({_cipher, opts}) ->
       opts[:default] == true

--- a/lib/cloak/util.ex
+++ b/lib/cloak/util.ex
@@ -1,0 +1,51 @@
+defmodule Cloak.Util do
+
+  def config(module) do
+    Application.get_env(:cloak, module)
+  end
+
+  def config(module, tag) do
+    module
+    |> config()
+    |> Keyword.get(:keys)
+    |> Enum.find(fn(key) -> key.tag == tag end)
+  end
+
+  def default_key(module) do
+    module
+    |> config()
+    |> Keyword.get(:keys)
+    |> Enum.find(fn(key) -> key.default end)
+  end
+
+  def key_value(key_config) do
+    case key_config.key do
+      {:system, env_var} ->
+        env_var
+        |> System.get_env()
+        |> validate_key!(env_var)
+        |> decode_key(env_var)
+
+      {:app_env, otp_app, env_var} ->
+        otp_app
+        |> Application.get_env(env_var)
+        |> validate_key!(env_var)
+
+      _ ->
+        key_config.key
+    end
+  end
+
+  defp decode_key(key, env_var) do
+    case Base.decode64(key) do
+      {:ok, decoded_key} -> decoded_key
+      :error -> raise "Expect env variable #{env_var} to be a valid base64 string."
+    end
+  end
+
+  defp validate_key!(key, env_var) when key in [nil, ""] do
+    raise "Expect env variable #{env_var} to define a key, but is empty."
+  end
+  defp validate_key!(key, _), do: key
+
+end

--- a/test/cloak_test.exs
+++ b/test/cloak_test.exs
@@ -28,7 +28,7 @@ defmodule CloakTest do
       @behaviour Cloak.Cipher
 
       def encrypt(plaintext, key_tag \\ nil) do
-        key = Cloak.Util.config(__MODULE__, key_tag) || Cloak.Util.default_key(__MODULE__)
+        key = Cloak.Ciphers.Util.config(__MODULE__, key_tag) || Cloak.Ciphers.Util.default_key(__MODULE__)
         key.tag <> Base.encode64(plaintext)
       end
 
@@ -36,7 +36,7 @@ defmodule CloakTest do
         Base.decode64!(ciphertext)
       end
 
-      def version, do: Cloak.Util.default_key(__MODULE__).tag
+      def version, do: Cloak.Ciphers.Util.default_key(__MODULE__).tag
     end
 
     setup do

--- a/test/cloak_test.exs
+++ b/test/cloak_test.exs
@@ -4,22 +4,64 @@ defmodule CloakTest do
 
   doctest Cloak
 
-  test ".encrypt can encrypt a value" do
-    assert encrypt("value") != "value"
+  describe "default cipher tests" do
+
+    test "Cloak.encrypt/1 can encrypt a value" do
+      refute encrypt("value") == "value"
+    end
+
+    test "Cloak.encrypt/1 prepends the cipher tag to the ciphertext" do
+      assert <<"AES", _ciphertext::binary>> = encrypt("value")
+    end
+
+    test "Cloak.decrypt/1 can decrypt a value" do
+      assert encrypt("value") |> decrypt == "value"
+    end
+
+    test "Cloak.version/0 returns the default cipher tag joined with the cipher.version" do
+      assert <<"AES", 1>> = version()
+    end
   end
 
-  test ".encrypt prepends the cipher tag to the ciphertext" do
-    assert <<"AES", _ciphertext::binary>> = encrypt("value")
+  describe "non default cipher tests" do
+    defmodule TestCipher do
+      @behaviour Cloak.Cipher
+
+      def encrypt(plaintext, key_tag \\ nil) do
+        key = Cloak.Util.config(__MODULE__, key_tag) || Cloak.Util.default_key(__MODULE__)
+        key.tag <> Base.encode64(plaintext)
+      end
+
+      def decrypt(<<_key_tag::binary-1, ciphertext::binary>> = _encrypted) do
+        Base.decode64!(ciphertext)
+      end
+
+      def version, do: Cloak.Util.default_key(__MODULE__).tag
+    end
+
+    setup do
+      non_default_cipher = [
+        default: false,
+        tag: "TEST",
+        keys: [
+          %{tag: <<1>>, key: "abc123xyz456", default: true},
+        ]
+      ]
+      Application.put_env(:cloak, TestCipher, non_default_cipher)
+
+      on_exit fn ->
+        Application.delete_env(:cloak, TestCipher)
+      end
+    end
+
+    test "Cloak.decrypt/1 can decrypt a value encrypted by a non-default encrypter" do
+      encrypted = encrypt("other_cipher_value", "TEST")
+      assert decrypt(encrypted) == "other_cipher_value"
+    end
+
+    test "Cloak.version/1 returns the non default cipher tag joined with the cipher.version" do
+      assert <<"TEST", 1>> = version("TEST")
+    end
   end
 
-  test ".decrypt can decrypt a value" do
-    assert encrypt("value") |> decrypt == "value"
-  end
-
-  test ".decrypt can decrypt a value encrypted by a non-default encryptor" do
-  end
-
-  test ".version returns the default cipher tag joined with the cipher.version" do
-    assert <<"AES", 1>> = version()
-  end
 end


### PR DESCRIPTION
This resolves #36.

Adds:
- `Cloak.Ciphers.Util` for dealing with generic key fetch operations from configs.
- Ability to use multiple ciphers with various tags. Previously would only encrypt with default cipher.
- Add tests surrounding new behavior
- Update docs
- Fix `decrypt/1` to no longer fail if the first cipher was not the matching cipher for the ciphertext.
- Add typespecs in a bunch of places

Let me know if there's anything else you need out of this! I'm going to be bringing these changes into a project, so I will get some real world testing into the mix, too. 