### PR TITLE
[#33] Add galois counter mode cipher

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,3 +9,13 @@ config :cloak, Cloak.AES.CTR,
     %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false},
     %{tag: <<4>>, key: {:app_env, :testapp, :encryption_key}, default: false}
   ]
+
+config :cloak, Cloak.AES.GCM,
+  tag: "GCM",
+  default: false,
+  keys: [
+    %{tag: <<1>>, key: :base64.decode("3Jnb0hZiHIzHTOih7t2cTEPEpY98Tu1wvQkPfq/XwqE="), default: true},
+    %{tag: <<2>>, key: :base64.decode("iutsyenD9K2psbQNIvdf/UTBYrFH1ONJlQUpQ6nRoAw="), default: false},
+    %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false},
+    %{tag: <<4>>, key: {:app_env, :testapp, :encryption_key}, default: false}
+  ]

--- a/lib/cloak/ciphers/aes_gcm.ex
+++ b/lib/cloak/ciphers/aes_gcm.ex
@@ -1,0 +1,175 @@
+defmodule Cloak.AES.GCM do
+  @moduledoc """
+  A `Cloak.Cipher` which encrypts values with the AES cipher in GCM (block) mode
+
+  ## Configuration
+
+  In addition to the normal `:default` and `tag` configuration options, this
+  cipher take a `:keys` option to support using multiple AES keys at the same time.
+
+    config :cloak, Cloak.AES.GCM,
+      default: true,
+      tag: "GCM",
+      keys: [
+        %{tag: <<1>>, key: Base.decode64!("..."), default: false},
+        %{tag: <<2>>, key: Base.decode64!("..."), default: true}
+      ]
+
+  If you want to store your key in the environment variable, you can use
+    `{:system, "VAR"}` syntax:
+        config :cloak, Cloak.AES.GCM,
+          default: true,
+          tag: "GCM",
+          keys: [
+            %{tag: <<1>>, key: {:system, "CLOAK_KEY_PRIMARY"}, default: true},
+            %{tag: <<2>>, key: {:system, "CLOAK_KEY_SECONDARY"}, default: false}
+          ]
+
+  If you want to store your key in the OTP app environment, you can use
+  `{:app_env, :otp_app, :env_key}` syntax:
+      config :cloak, Cloak.AES.GCM,
+        default: true,
+        tag: "GCM",
+        keys: [
+          %{tag: <<1>>, key: {:app_env, :my_app, :env_primary_key}, default: true},
+          %{tag: <<2>>, key: {:app_env, :my_app, :env_secondary_key}, default: false}
+        ]
+
+  ### Key Configuration Options
+
+  A key may have the following attributes:
+
+  - `:tag` - The ID of the key. This is included in the ciphertext, and should be
+    only a single byte. See `encrypt/2` for more details.
+
+  - `:key` - The AES key to use, in binary. If you store your keys in Base64
+    format you will need to decode them first. The key must be 128, 192, or 256 bits
+    long (16, 24 or 32 bytes, respectively).
+
+  - `:default` - Boolean. Whether to use this key by default or not.
+
+  ## Upgrading to a New Key
+
+  To upgrade to a new key, simply add the key to the `:keys` array, and set it
+  as `default: true`.
+
+      keys: [
+        %{tag: <<1>>, key: "old key", default: false},
+        %{tag: <<2>>, key: "new key", default: true}
+      ]
+
+  After this, your new key will automatically be used for all new encyption,
+  while the old key will be used to decrypt legacy values.
+
+  To migrate everything proactively to the new key, see the `mix cloak.migrate`
+  mix task defined in `Mix.Tasks.Cloak.Migrate`.
+  """
+
+  import Cloak.Tags.Encoder
+  import Cloak.Tags.Decoder
+
+  @behaviour Cloak.Cipher
+  @aad "AES256GCM"
+
+  @doc """
+
+  Callback implementation for `Cloak.Cipher.encrypt`. Encrypts a value using
+  AES in CTR mode.
+
+  Generates a random IV for every encryption, and prepends the key tag, IV, and Ciphertag to
+  the beginning of the ciphertext. The format can be diagrammed like this:
+
+  +----------------------------------------------------------+----------------------+
+  |                          HEADER                          |         BODY         |
+  +-------------------+---------------+----------------------+----------------------+
+  | Key Tag (n bytes) | IV (16 bytes) | Ciphertag (16 bytes) | Ciphertext (n bytes) |
+  +-------------------+---------------+----------------------+----------------------+
+
+  When this function is called through `Cloak.encrypt/1`, the module's `:tag`
+  will be added, and the resulting binary will be in this format:
+
+  +---------------------------------------------------------------------------------+----------------------+
+  |                                       HEADER                                    |         BODY         |
+  +----------------------+-------------------+---------------+----------------------+----------------------+
+  | Module Tag (n bytes) | Key Tag (n bytes) | IV (16 bytes) | Ciphertag (16 bytes) | Ciphertext (n bytes) |
+  +----------------------+-------------------+---------------+----------------------+----------------------+
+
+  The header information allows Cloak to know enough about each ciphertext to
+  ensure a successful decryption. See `decrypt/1` for more details.
+
+  **Important**: Because a random IV is used for every encryption, `encrypt/2`
+  will not produce the same ciphertext twice for the same value.
+
+  ### Parameters
+
+  - `plaintext` - Any type of value to encrypt.
+  - `key_tag` - Optional. The tag of the key to use for encryption.
+
+  ### Examples
+    iex> encrypt("The charge against me is a...") != "The charge against me is a..."
+    true
+
+    iex> encrypt("The charge against me is a...") != encrypt("The charge against me is a...")
+    true
+
+  """
+
+  def encrypt(plain_text, key_tag \\ nil) do
+    perform_encryption(plain_text, iv(), find_key(key_tag))
+  end
+
+  defp perform_encryption(plaintext, iv, key) do
+    {ciphertext, ciphertag} = :crypto.block_encrypt(
+      :aes_gcm,
+      Cloak.Ciphers.Util.key_value(key),
+      iv,
+      {@aad, plaintext}
+    )
+
+    encode(key.tag) <> iv <> ciphertag <> ciphertext
+  end
+
+  @doc """
+  Callback implementation for `Cloak.Cipher.decrypt/2`. Decrypts a value
+  encrypted with AES in GCM mode.
+
+  Uses the key tag to find the correct key for decryption, and the IV and Ciphertag included
+  in the header to decrypt the body of the ciphertext.
+
+  ### Parameters
+
+  - `ciphertext` - Binary ciphertext generated by `encrypt/2`.
+
+  ### Examples
+
+    iex> encrypt("Hello") |> decrypt
+    "Hello"
+  """
+
+  def decrypt(message) do
+    %{key_tag: key_tag, remainder: remainder} = decode(message)
+
+    perform_decryption(
+      Cloak.Ciphers.Util.key_value(find_key(key_tag)),
+      remainder
+    )
+  end
+
+  defp perform_decryption(key, <<iv::binary-16, ciphertag::binary-16, ciphertext::binary>>) do
+    :crypto.block_decrypt(:aes_gcm, key, iv, {@aad, ciphertext, ciphertag})
+  end
+
+  defp iv, do: :crypto.strong_rand_bytes(16)
+
+  defp find_key(key_tag) do
+    Cloak.Ciphers.Util.config(__MODULE__, key_tag) || default_key()
+  end
+
+  defp default_key, do: Cloak.Ciphers.Util.default_key(__MODULE__)
+
+  @doc """
+    Callback implementation for `Cloak.Cipher.version/0`. Returns the tag of the
+    current default key.
+  """
+  def version, do: default_key().tag
+end

--- a/lib/cloak/tags/decoder.ex
+++ b/lib/cloak/tags/decoder.ex
@@ -1,0 +1,51 @@
+defmodule Cloak.Tags.Decoder do
+  @moduledoc """
+  A decoder that will let us read tags specified in the Format specified by the `Cloak.Tags.Encoder`
+
+  This scheme follows a Type, Length, Value triplet and is based on DER encoding for certificates
+  https://en.wikipedia.org/wiki/X.690#DER_encoding
+
+  It returns a map containing the key_tag and the remainder of the binary which we can use
+  to decode the ciphertext.
+  """
+
+  @offset 2
+  @byte_length 256
+  @half_byte 128
+
+  def decode(message) do
+    length = tag_length(message)
+    <<tlv :: binary-size(length), remainder :: binary>> = message
+
+    %{key_tag: key_tag(tlv), remainder: remainder}
+  end
+
+  defp tag_length(message) do
+    <<_type :: size(8), len :: size(8), rest :: binary>> = message
+
+    tag_length(len, :binary.bin_to_list(rest))
+  end
+
+  defp tag_length(num, list) when num >= @half_byte do
+    @offset + num - @half_byte + value_bytes(list, num - @half_byte)
+  end
+
+  defp tag_length(num, _list), do: @offset + num
+
+  defp key_tag(<<_type :: size(8), len :: size(8), rest :: binary>>) when len >= @half_byte do
+    size = len - @half_byte
+    <<_value_bytes :: binary-size(size), key_tag :: binary>> = rest
+
+    key_tag
+  end
+
+  defp key_tag(<<_type :: size(8), _len :: size(8), key_tag :: binary>>) do
+    key_tag
+  end
+
+  defp value_bytes(list, num_bytes) do
+    list
+    |> Enum.take(num_bytes)
+    |> Enum.reduce(0, fn(value, acc) -> acc * @byte_length + value end)
+  end
+end

--- a/lib/cloak/tags/encoder.ex
+++ b/lib/cloak/tags/encoder.ex
@@ -1,0 +1,58 @@
+defmodule Cloak.Tags.Encoder do
+  @moduledoc """
+  An encoder that allows us to specify tags of arbitrary length.
+
+  This scheme follows a Type, Length, Value triplet and is based on DER encoding for certificates
+  https://en.wikipedia.org/wiki/X.690#DER_encoding
+
+  If the value field (tag) is less than 128 bytes, the Length field only requires 1 byte
+
+  If the Value field contains more than 127 bytes, bit 7 of the Length field is one (1)
+  and the remaining bits identify the number of bytes needed to contain the length.
+
+  Examples are shown in the following illustration.
+
+  +---+---+---+---+---+---+---+---+----------------+
+  | 0 | 0 | 1 | 1 | 0 | 1 | 0 | 0 | 52 value bytes |
+  +---+---+---+---+---+---+---+---+----------------+
+  <===   Length Bytes == 52  ====>
+
+
+  +---+---+---+---+---+---+---+---++---+---+---+---+---+---+---+---++---+---+---+---+---+---+---+---+------------------+
+  | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 0 || 0 | 0 | 0 | 1 | 0 | 0 | 1 | 1 || 0 | 1 | 0 | 0 | 0 | 1 | 1 | 0 | 4934 value bytes |
+  +---+---+---+---+---+---+---+---++---+---+---+---+---+---+---+---++---+---+---+---+---+---+---+---+------------------+
+  <===   Length Bytes == 2  ====>   <=====         Number of Value Bytes == 4934              =====>
+
+  We reserve the first byte for potential use in the future, as it represents the tag in the TLV triplet
+  """
+
+  @reserved <<1>>
+  @byte_length 256
+  @half_byte 128
+
+  def encode(value) when byte_size(value) >= @half_byte do
+    value |> byte_size() |> to_bitstring() |> encode(value)
+  end
+
+  def encode(value) do
+    @reserved <> <<byte_size(value)>> <> value
+  end
+
+  def encode(bitstring, value) do
+    @reserved <> <<(@half_byte + byte_size(bitstring))>> <> bitstring <> value
+  end
+
+  defp to_bitstring(decimal) do
+    decimal
+    |> convert()
+    |> Enum.map(fn(num) -> <<num>> end)
+    |> Enum.join()
+  end
+
+  defp convert(decimal), do: convert(decimal, [])
+  defp convert(0, list), do: list
+
+  defp convert(decimal, list) do
+    convert(div(decimal, @byte_length), [rem(decimal, @byte_length) | list ])
+  end
+end

--- a/test/cloak/ciphers/aes_gcm_test.exs
+++ b/test/cloak/ciphers/aes_gcm_test.exs
@@ -1,0 +1,43 @@
+defmodule Cloak.AES.GCMTest do
+  use ExUnit.Case
+  import Cloak.AES.GCM
+
+  doctest Cloak.AES.GCM
+
+  test ".encrypt can encrypt a value" do
+    assert encrypt("value") != "value"
+  end
+
+  test ".encrypt can encrypt a value with different keys" do
+    assert encrypt("value", <<1>>) != encrypt("value", <<2>>)
+  end
+
+  test ".encrypt returns ciphertext in the format key_tag <> iv <> ciphertag <> ciphertext" do
+    assert <<1, iv::binary-16, ciphertag::binary-16, ciphertext::binary>> = encrypt("value", <<1>>)
+    assert byte_size(iv) == 16
+    assert byte_size(ciphertag) == 16
+    assert String.length(ciphertext) > 0
+  end
+
+  test ".encrypt can encrypt a value using an environment variable as key" do
+    System.put_env("CLOAK_THIRD_KEY", "NhsNVkstdaUiXIh6fFZaRu+O6gK/p9C9LKJr3kkEWNA=")
+
+    assert encrypt("value", <<3>>) != "value"
+  end
+
+  test ".encrypt can encrypt a value using an OTP environment variable as key" do
+    encryption_key = <<54, 27, 13, 86, 75, 45, 117, 165, 34, 92, 136, 122, 124, 86, 90, 70, 239,
+   142, 234, 2, 191, 167, 208, 189, 44, 162, 107, 222, 73, 4, 88, 208>>
+    Application.put_env(:testapp, :encryption_key, encryption_key)
+
+    assert encrypt("value", <<4>>) != "value"
+  end
+
+  test ".decrypt can decrypt a value" do
+    assert encrypt("value") |> decrypt == "value"
+  end
+
+  test ".decrypt can decrypt a value encrypted with a non-default key" do
+    assert encrypt("value", <<2>>) |> decrypt == "value"
+  end
+end

--- a/test/cloak/tags/decoder_test.exs
+++ b/test/cloak/tags/decoder_test.exs
@@ -1,0 +1,20 @@
+defmodule Cloak.Tags.DecoderTest do
+  import Cloak.Tags.Decoder
+  use ExUnit.Case, async: true
+
+  doctest Cloak.Tags.Decoder
+
+  describe "Cloak.Tags.Encoder/1" do
+    test "it returns a key_tag and remainder as a map" do
+      assert decode(<<1,4,25,13,33,41,1,2>>) == %{key_tag: <<25,13,33,41>>, remainder: <<1,2>>}
+    end
+
+    test "it can decode tags of arbitrary length" do
+      tag = 1..4934 |> Enum.to_list() |> Enum.map(fn(num) -> <<num>> end) |> Enum.join()
+      assert decode(<<1, 130, 19, 70>> <> tag <> <<20, 30, 12>>) == %{
+        key_tag: tag,
+        remainder: <<20, 30, 12>>
+      }
+    end
+  end
+end

--- a/test/cloak/tags/encoder_test.exs
+++ b/test/cloak/tags/encoder_test.exs
@@ -1,0 +1,17 @@
+defmodule Cloak.Tags.EncoderTest do
+  import Cloak.Tags.Encoder
+  use ExUnit.Case, async: true
+
+  doctest Cloak.Tags.Encoder
+
+  describe "Cloak.Tags.Encoder/1" do
+    test "when byte_size(tag) < 128 it returns a bitstring with the length as second byte" do
+      assert encode(<<25,13,33,41>>) == <<1,4,25,13,33,41>>
+    end
+
+    test "when byte_size(tag) >= 128 it returns a bitstring with the length of value as multiple bytes" do
+      tag = 1..4934 |> Enum.to_list() |> Enum.map(fn(num) -> <<num>> end) |> Enum.join()
+      assert encode(tag) == <<1, 130, 19, 70>> <> tag
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the AESGCM block cipher which I think could eventually be the default cipher that should ship with Cloak. This form of encryption provides confidentiality, integrity and authenticity assurances on the data that CTR does not provide. The API should be exactly the same as CTR.

In addition I've added arbitrary length tagging instead of hard coding 1 bit for the tag value. This allows to keep more than 255 keys simultaneously for a single cipher. (future proofing) Let me know if you have any questions regarding the implementation or want me to add more context or change anything.