### PR TITLE
refactor(Cloak.Config.all/0): Find ciphers by checking if the module …

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -35,3 +35,5 @@ config :cloak, Cloak.AES.GCM,
     %{tag: <<3>>, key: {:system, "CLOAK_THIRD_KEY"}, default: false},
     %{tag: <<4>>, key: {:app_env, :testapp, :encryption_key}, default: false}
   ]
+
+config :cloak, json_library: Poison

--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -3,8 +3,8 @@ defmodule Cloak.Config do
 
   @spec all() :: Keyword.t()
   def all() do
-    Enum.reject(Application.get_all_env(:cloak), fn {key, _} ->
-      key in [:migration, :included_applications, :json_library]
+    Enum.filter(Application.get_all_env(:cloak), fn {key, _} ->
+      cipher?(key)
     end)
   end
 
@@ -36,5 +36,14 @@ defmodule Cloak.Config do
     end
 
     cipher
+  end
+
+  defp cipher?(module) do
+    case Code.ensure_loaded(module) do
+      {:module, _} ->
+        function_exported?(module, :__info__, 1) &&
+        Cloak.Cipher in Keyword.get(module.__info__(:attributes), :behaviour, [])
+      _ -> false
+    end
   end
 end

--- a/test/cloak/config_test.exs
+++ b/test/cloak/config_test.exs
@@ -1,0 +1,25 @@
+defmodule Cloak.ConfigTest do
+  use ExUnit.Case, async: true
+
+  describe "#all" do
+    setup do
+      modules = Cloak.Config.all()
+      |> Enum.map(fn {key, _} -> key end)
+      |> MapSet.new()
+
+      {:ok, modules: modules}
+    end
+
+    test "it includes Cloak.AES.GCM", context do
+      assert MapSet.member?(context[:modules], Cloak.AES.GCM)
+    end
+
+    test "it includes Cloak.AES.CTR", context do
+      assert MapSet.member?(context[:modules], Cloak.AES.CTR)
+    end
+
+    test "it doesn't include :json_library", context do
+      refute MapSet.member?(context[:modules], :json_library)
+    end
+  end
+end


### PR DESCRIPTION
…exports the Cloak.Cipher behaviour

This is a refactor for the `Cloak.Config.all/0` method discussed in #43. Instead of blacklisting atoms it will check if the module is a `Cloak.Cipher`.