### PR TITLE
perf(Cloak.Config.all/0): remove calls to ensure_loaded when checking…

### DIFF
--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -39,13 +39,7 @@ defmodule Cloak.Config do
   end
 
   defp cipher?(module) do
-    case Code.ensure_loaded(module) do
-      {:module, _} ->
-        function_exported?(module, :__info__, 1) &&
-          Cloak.Cipher in Keyword.get(module.__info__(:attributes), :behaviour, [])
-
-      _ ->
-        false
-    end
+    function_exported?(module, :__info__, 1) &&
+      Cloak.Cipher in Keyword.get(module.__info__(:attributes), :behaviour, [])
   end
 end


### PR DESCRIPTION
… for ciphers

@danielberkompas I noticed a fairly significant slowdown in my test suite (229 => 590 secs) after updating cloak to 0.5.0. I tracked it down to the following lines. (that I myself added) I originally added the `ensure_loaded` as an additional safety check but it should not be necessary. 

On a separate note it may be useful to add a dummy cipher for testing so that we don't actually perform any expensive encrypting or decrypting calls. If you think that is a good idea, I will explore adding it to the codebase.