### PR TITLE
Add support for encrypted Ecto String and Integer Array types.

### DIFF
--- a/lib/cloak/types/encrypted_integer_array_field.ex
+++ b/lib/cloak/types/encrypted_integer_array_field.ex
@@ -1,0 +1,41 @@
+defmodule Cloak.EncryptedIntegerArrayField do
+  @moduledoc """
+  An `Ecto.Type` to encrypt an array (list) of integers.
+
+  ## Configuration
+  You can customize the json library used for for converting maps.
+  Default: `Poison`
+      config :cloak, json_library: Jason
+  ## Usage
+  You should create the field with type `:binary`. On encryption, the list
+  will first be converted to JSON using the configured `:json_library`, and
+  then encrypted. On decryption, the `:json_library` will be used to convert
+  it back to a list of integer.
+        
+  You can use this field type in your `schema` definition like this:
+      schema "table" do
+        field :field_name, Cloak.EncryptedIntegerArrayField
+      end
+
+  Use it where you would have normally done this:
+      schema "table" do
+        field :field_name, {:array, :integer}
+      end
+  """
+
+  use Cloak.EncryptedField
+
+  alias Cloak.Config
+
+  def cast(value) do
+    Ecto.Type.cast({:array, :integer}, value)
+  end
+
+  def before_encrypt(value) do
+    Config.json_library().encode!(value)
+  end
+
+  def after_decrypt(json) do
+    Config.json_library().decode!(json)
+  end
+end

--- a/lib/cloak/types/encrypted_string_array_field.ex
+++ b/lib/cloak/types/encrypted_string_array_field.ex
@@ -11,7 +11,7 @@ defmodule Cloak.EncryptedStringArrayField do
   will first be converted to JSON using the configured `:json_library`, and
   then encrypted. On decryption, the `:json_library` will be used to convert
   it back to a list of strings.
-  
+
   This means that on decryption, atom members of the list will become strings.
       ["hello", :world]
   Will become:

--- a/lib/cloak/types/encrypted_string_array_field.ex
+++ b/lib/cloak/types/encrypted_string_array_field.ex
@@ -1,0 +1,46 @@
+defmodule Cloak.EncryptedStringArrayField do
+  @moduledoc """
+  An `Ecto.Type` to encrypt an array (list) of strings.
+
+  ## Configuration
+  You can customize the json library used for for converting maps.
+  Default: `Poison`
+      config :cloak, json_library: Jason
+  ## Usage
+  You should create the field with type `:binary`. On encryption, the list
+  will first be converted to JSON using the configured `:json_library`, and
+  then encrypted. On decryption, the `:json_library` will be used to convert
+  it back to a list of strings.
+  
+  This means that on decryption, atom members of the list will become strings.
+      ["hello", :world]
+  Will become:
+      ["hello", "world"]
+
+  You can use this field type in your `schema` definition like this:
+      schema "table" do
+        field :field_name, Cloak.EncryptedStringArrayField
+      end
+
+  Use it where you would have normally done this:
+      schema "table" do
+        field :field_name, {:array, :string}
+      end
+  """
+
+  use Cloak.EncryptedField
+
+  alias Cloak.Config
+
+  def cast(value) do
+    Ecto.Type.cast({:array, :string}, value)
+  end
+
+  def before_encrypt(value) do
+    Config.json_library().encode!(value)
+  end
+
+  def after_decrypt(json) do
+    Config.json_library().decode!(json)
+  end
+end

--- a/test/cloak/types/encrypted_integer_array_field_test.exs
+++ b/test/cloak/types/encrypted_integer_array_field_test.exs
@@ -1,0 +1,38 @@
+defmodule Cloak.EncryptedIntegerArrayFieldTest do
+  use ExUnit.Case
+  alias Cloak.EncryptedIntegerArrayField, as: Field
+
+  @list [1, 2, 3, 4, 5]
+
+  test ".type is :binary" do
+    assert Field.type() == :binary
+  end
+
+  test ".cast rejects invalid types" do
+    assert :error = Field.cast("binary")
+    assert :error = Field.cast(123)
+    assert :error = Field.cast(123.0)
+    assert :error = Field.cast(hello: :world)
+    assert :error = Field.cast(%{hello: :world})
+    assert :error = Field.cast(["list", "of", "strings"])
+  end
+
+  test ".cast accepts lists" do
+    assert {:ok, @list} = Field.cast(@list)
+  end
+
+  test ".before_encrypt converts the list to a JSON string" do
+    assert "[1,2,3,4,5]" = Field.before_encrypt(@list)
+  end
+
+  test ".dump encrypts the list" do
+    {:ok, ciphertext} = Field.dump(@list)
+    assert is_binary(ciphertext)
+    assert ciphertext != @list
+  end
+
+  test ".load decrypts the list" do
+    {:ok, ciphertext} = Field.dump(@list)
+    assert {:ok, @list} = Field.load(ciphertext)
+  end
+end

--- a/test/cloak/types/encrypted_string_array_field_test.exs
+++ b/test/cloak/types/encrypted_string_array_field_test.exs
@@ -1,0 +1,41 @@
+defmodule Cloak.EncryptedStringArrayFieldTest do
+  use ExUnit.Case
+  alias Cloak.EncryptedStringArrayField, as: Field
+
+  @list ["A", "list", "of", "strings"]
+
+  test ".type is :binary" do
+    assert Field.type() == :binary
+  end
+
+  test ".cast rejects invalid types" do
+    assert :error = Field.cast("binary")
+    assert :error = Field.cast(123)
+    assert :error = Field.cast(123.0)
+    assert :error = Field.cast(hello: :world)
+    assert :error = Field.cast(%{hello: :world})
+  end
+
+  test ".cast accepts lists" do
+    assert {:ok, ["hello", "world"]} = Field.cast(["hello", "world"])
+  end
+
+  test ".before_encrypt converts the list to a JSON string" do
+    assert "[\"A\",\"list\",\"of\",\"strings\"]" = Field.before_encrypt(@list)
+  end
+
+  test ".before_encrypt handles list elements that are atoms" do
+    assert "[\"A\",\"mixed\",\"list\"]" = Field.before_encrypt(["A", :mixed, "list"])
+  end
+
+  test ".dump encrypts the list" do
+    {:ok, ciphertext} = Field.dump(@list)
+    assert is_binary(ciphertext)
+    assert ciphertext != @list
+  end
+
+  test ".load decrypts the list" do
+    {:ok, ciphertext} = Field.dump(@list)
+    assert {:ok, @list} = Field.load(ciphertext)
+  end
+end


### PR DESCRIPTION
Had a need to encrypt an array of strings (a supported Ecto type) in the db. Example use case is a list of permissions in a record. This used to work in Cloak version 0.3 by using the EncryptedMapField because it was simply running the data through Json without actually casting into Ecto. Newer versions cloak do more type checking, so the Ecto type {:array, :string} fails now.

This PR creates two new encrypted field types corresponding to the Ecto types of {:array, :string} and {:array, :integer}. They are simple variations of the existing Map type. Docs and tests for both have been added/updated.