### PR TITLE
bugfix(cipher?): Rescue from UndefinedFunctionError instead of using …

### DIFF
--- a/lib/cloak/config.ex
+++ b/lib/cloak/config.ex
@@ -39,7 +39,14 @@ defmodule Cloak.Config do
   end
 
   defp cipher?(module) do
-    function_exported?(module, :__info__, 1) &&
-      Cloak.Cipher in Keyword.get(module.__info__(:attributes), :behaviour, [])
+    Cloak.Cipher in Keyword.get(attributes_for(module), :behaviour, [])
+  end
+
+  defp attributes_for(module) do
+    try do
+      module.__info__(:attributes)
+    rescue
+      UndefinedFunctionError -> []
+    end
   end
 end


### PR DESCRIPTION
…function_exported?. Fixes module loading issues w/o perf problems.

Just updated to version 0.6.0 and am running into issues of my own doing. My implementation for cipher checking is not reliable enough so here is a modification that should fix the issue. `function_exported` is not reliable enough since it needs the module to have been loaded in order to work as you expect. In lieu of trying to check that a module responds to the `__info__` method we should just call it and rescue from the error with an empty list. Once this gets merged you should cut a new version since this issue will cause a bunch of headaches. I'm going to open up an issue on the Elixir mailing list as I think checking if an atom is a module should be better handled in the language. Sorry for the bugs. 