### PR TITLE
[Documentation] Fix small typo: SHA265 -> SHA256

### DIFF
--- a/lib/cloak.ex
+++ b/lib/cloak.ex
@@ -87,9 +87,9 @@ defmodule Cloak do
 
   You can also use the following `Ecto.Type` modules in order to hash fields:
 
-  | Type      | Ecto Type              | Field               | 
+  | Type      | Ecto Type              | Field               |
   | --------- | ---------------------- | ------------------- |
-  | `String`  | `:string` / `:binary`  | `Cloak.SHA265Field` |
+  | `String`  | `:string` / `:binary`  | `Cloak.SHA256Field` |
 
   For example, to encrypt a binary field, change your schema from this:
 


### PR DESCRIPTION
First of all, thanks for creating this library ❤️ 

This PR fixes a small typo I found in the documentation for the `Cloak` module.

If there are any additional contribution steps I need to follow, please let me know!