### PR TITLE
Improve nil support in Ecto types

### DIFF
--- a/lib/cloak/field.ex
+++ b/lib/cloak/field.ex
@@ -14,13 +14,22 @@ defmodule Cloak.Field do
       def type, do: :binary
 
       @doc false
+      def cast(nil) do
+        {:ok, nil}
+      end
+
       def cast(value) do
         {:ok, value}
       end
 
       @doc false
+      def dump(nil) do
+        {:ok, nil}
+      end
+
       def dump(value) do
-        with value <- before_encrypt(value),
+        with {:ok, value} <- cast(value),
+             value <- before_encrypt(value),
              {:ok, value} <- encrypt(value) do
           {:ok, value}
         else
@@ -30,6 +39,10 @@ defmodule Cloak.Field do
       end
 
       @doc false
+      def load(nil) do
+        {:ok, nil}
+      end
+
       def load(value) do
         with {:ok, value} <- decrypt(value) do
           value = after_decrypt(value)

--- a/lib/cloak/fields/binary.ex
+++ b/lib/cloak/fields/binary.ex
@@ -15,6 +15,10 @@ defmodule Cloak.Fields.Binary do
 
     quote location: :keep do
       use Cloak.Field, unquote(opts)
+
+      def cast(value) do
+        Ecto.Type.cast(:string, value)
+      end
     end
   end
 end

--- a/test/cloak/fields/binary_test.exs
+++ b/test/cloak/fields/binary_test.exs
@@ -5,17 +5,51 @@ defmodule Cloak.Fields.BinaryTest do
     use Cloak.Fields.Binary, vault: Cloak.TestVault
   end
 
-  test ".type is :binary" do
-    assert Field.type() == :binary
+  @invalid_types [%{}, 123, 123.33, []]
+
+  describe ".type/0" do
+    test "returns :binary" do
+      assert Field.type() == :binary
+    end
   end
 
-  test ".dump encrypts the value" do
-    {:ok, ciphertext} = Field.dump("value")
-    assert ciphertext != "value"
+  describe ".cast/1" do
+    test "leaves nil unchanged" do
+      assert {:ok, nil} == Field.cast(nil)
+    end
+
+    test "leaves binaries unchanged" do
+      assert {:ok, "binary"} = Field.cast("binary")
+    end
+
+    test "returns :error on other types" do
+      for invalid <- @invalid_types do
+        assert :error == Field.cast(invalid)
+      end
+    end
   end
 
-  test ".load decrypts the ciphertext" do
-    {:ok, ciphertext} = Field.dump("value")
-    assert {:ok, "value"} = Field.load(ciphertext)
+  describe "dump/1" do
+    test "leaves nil unchanged" do
+      assert {:ok, nil} == Field.dump(nil)
+    end
+
+    test "encrypts binaries" do
+      {:ok, ciphertext} = Field.dump("value")
+      assert ciphertext != "value"
+    end
+
+    test "returns :error on other types" do
+      for invalid <- @invalid_types do
+        assert :error == Field.dump(invalid)
+      end
+    end
+  end
+
+  describe ".load/1" do
+    test "decrypts the ciphertext" do
+      {:ok, ciphertext} = Field.dump("value")
+      assert {:ok, "value"} = Field.load(ciphertext)
+    end
   end
 end


### PR DESCRIPTION
We want to be sure that nils will be properly casted, dumped, and loaded
as nils, rather than converted to empty strings.