### PR TITLE
Add support for PBKDF2 for blind indexing

### DIFF
--- a/lib/cloak/fields/pbkdf2.ex
+++ b/lib/cloak/fields/pbkdf2.ex
@@ -118,7 +118,6 @@ if Code.ensure_loaded?(:pbkdf2) do
           sha384
           sha512
         ]a
-        @sizes [16, 32, 64, 128]
 
         @impl Cloak.Fields.PBKDF2
         def init(config) do
@@ -180,11 +179,11 @@ if Code.ensure_loaded?(:pbkdf2) do
                   "#{iterations} must be a positive integer for #{inspect(__MODULE__)}"
           end
 
-          unless config[:size] in @sizes do
+          unless is_integer(config[:size]) && config[:size] > 0 do
             size = inspect(config[:size])
 
             raise Cloak.InvalidConfig,
-              "#{size} should be one of 16, 32, 64, or 128 for #{inspect(__MODULE__)}"
+                  "#{size} should be a positive integer for #{inspect(__MODULE__)}"
           end
 
           config

--- a/lib/cloak/fields/pbkdf2.ex
+++ b/lib/cloak/fields/pbkdf2.ex
@@ -1,192 +1,194 @@
-defmodule Cloak.Fields.PBKDF2 do
-  @moduledoc """
-  A custom `Ecto.Type` for deriving a key for fields using
-  [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2).
+if Code.ensure_loaded?(:pbkdf2) do
+  defmodule Cloak.Fields.PBKDF2 do
+    @moduledoc """
+    A custom `Ecto.Type` for deriving a key for fields using
+    [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2).
 
-  PBKDF2 is **more secure** than `Cloak.Fields.HMAC` and
-  `Cloak.Fields.SHA256` because it uses [key
-  stretching](https://en.wikipedia.org/wiki/Key_stretching) to increase the
-  amount of time to compute hashes. This slows down brute-force attacks.
+    PBKDF2 is **more secure** than `Cloak.Fields.HMAC` and
+    `Cloak.Fields.SHA256` because it uses [key
+    stretching](https://en.wikipedia.org/wiki/Key_stretching) to increase the
+    amount of time to compute hashes. This slows down brute-force attacks.
 
-  ## Why
+    ## Why
 
-  If you store a hash of a field's value, you can then query on it as a proxy
-  for an encrypted field. This works because PBKDF2 is deterministic and
-  always results in the same value, while secure encryption does not. Be
-  warned, however, that hashing will expose which fields have the same value,
-  because they will contain the same hash.
+    If you store a hash of a field's value, you can then query on it as a proxy
+    for an encrypted field. This works because PBKDF2 is deterministic and
+    always results in the same value, while secure encryption does not. Be
+    warned, however, that hashing will expose which fields have the same value,
+    because they will contain the same hash.
 
-  ## Configuration
+    ## Configuration
 
-  Create a `PBKDF2` field in your project:
+    Create a `PBKDF2` field in your project:
 
-      defmodule MyApp.Hashed.PBKDF2 do
-        use Cloak.Fields.PBKDF2, otp_app: :my_app
-      end
+    defmodule MyApp.Hashed.PBKDF2 do
+    use Cloak.Fields.PBKDF2, otp_app: :my_app
+    end
 
-  Then, configure it with a `:secret`, an `:algorithm`, the maximum `:size`
-  of the stored key (in bytes), and a number of `:iterations`, either using
-  mix configuration:
+    Then, configure it with a `:secret`, an `:algorithm`, the maximum `:size`
+    of the stored key (in bytes), and a number of `:iterations`, either using
+    mix configuration:
 
-      config :my_app, MyApp.Hashed.PBKDF2,
-        algorithm: :sha256,
-        iterations: 10_000,
-        secret: "secret"
+    config :my_app, MyApp.Hashed.PBKDF2,
+    algorithm: :sha256,
+    iterations: 10_000,
+    secret: "secret"
 
-  Or using the `init/1` callback to fetch configuration at runtime:
+    Or using the `init/1` callback to fetch configuration at runtime:
 
-      defmodule MyApp.Hashed.PBKDF2 do
-        use Cloak.Fields.PBKDF2, otp_app: :my_app
+    defmodule MyApp.Hashed.PBKDF2 do
+    use Cloak.Fields.PBKDF2, otp_app: :my_app
+
+    @impl Cloak.Fields.PBKDF2
+    def init(config) do
+    config = Keyword.merge(config, [
+    algorithm: :sha256,
+    iterations: 10_000,
+    secret: System.get_env("PBKDF2_SECRET")
+    ])
+
+    {:ok, config}
+    end
+    end
+
+    ## Usage
+
+    Create the hash field with the type `:binary`. Add it to your schema
+    definition like this:
+
+    schema "table" do
+    field :field_name, MyApp.Encrypted.Binary
+    field :field_name_hash, MyApp.Hashed.PBKDF2
+    end
+
+    Ensure that the hash is updated whenever the target field changes with the
+    `put_change/3` function:
+
+    def changeset(struct, attrs \\\\ %{}) do
+    struct
+    |> cast(attrs, [:field_name, :field_name_hash])
+    |> put_hashed_fields()
+    end
+
+    defp put_hashed_fields(changeset) do
+    changeset
+    |> put_change(:field_name_hash, get_field(changeset, :field_name))
+    end
+
+    Query the Repo using the `:field_name_hash` in any place you would typically
+    query by `:field_name`.
+
+    user = Repo.get_by(User, email_hash: "user@email.com")
+    """
+
+    @typedoc "Digest algorithms supported by Cloak.Field.PBKDF2"
+    @type algorithms :: :md4 | :md5 | :ripemd160 | :sha | :sha224 | :sha256 | :sha384 | :sha512
+
+    @doc """
+    Configures the `PBKDF2` field using runtime information.
+
+    ## Example
+
+    @impl Cloak.Fields.PBKDF2
+    def init(config) do
+    config = Keyword.merge(config, [
+    algorithm: :sha256,
+    secret: System.get_env("PBKDF2_SECRET")
+    ])
+
+    {:ok, config}
+    end
+    """
+    @callback init(config :: Keyword.t()) :: {:ok, Keyword.t()} | {:error, any}
+
+    @doc false
+    defmacro __using__(opts) do
+      otp_app = Keyword.fetch!(opts, :otp_app)
+
+      quote do
+        @behaviour Cloak.Fields.PBKDF2
+        @behaviour Ecto.Type
+        @algorithms ~w[
+          md4
+          md5
+          ripemd160
+          sha
+          sha224
+          sha256
+          sha384
+          sha512
+        ]a
+        @sizes [16, 32, 64, 128]
 
         @impl Cloak.Fields.PBKDF2
         def init(config) do
-          config = Keyword.merge(config, [
-            algorithm: :sha256,
-            iterations: 10_000,
-            secret: System.get_env("PBKDF2_SECRET")
-          ])
+          defaults = [algorithm: :sha256, iterations: 10_000, size: 32]
 
-          {:ok, config}
-        end
-      end
-
-  ## Usage
-
-  Create the hash field with the type `:binary`. Add it to your schema
-  definition like this:
-
-      schema "table" do
-        field :field_name, MyApp.Encrypted.Binary
-        field :field_name_hash, MyApp.Hashed.PBKDF2
-      end
-
-  Ensure that the hash is updated whenever the target field changes with the
-  `put_change/3` function:
-
-      def changeset(struct, attrs \\\\ %{}) do
-        struct
-        |> cast(attrs, [:field_name, :field_name_hash])
-        |> put_hashed_fields()
-      end
-
-      defp put_hashed_fields(changeset) do
-        changeset
-        |> put_change(:field_name_hash, get_field(changeset, :field_name))
-      end
-
-  Query the Repo using the `:field_name_hash` in any place you would typically
-  query by `:field_name`.
-
-      user = Repo.get_by(User, email_hash: "user@email.com")
-  """
-
-  @typedoc "Digest algorithms supported by Cloak.Field.PBKDF2"
-  @type algorithms :: :md4 | :md5 | :ripemd160 | :sha | :sha224 | :sha256 | :sha384 | :sha512
-
-  @doc """
-  Configures the `PBKDF2` field using runtime information.
-
-  ## Example
-
-      @impl Cloak.Fields.PBKDF2
-      def init(config) do
-        config = Keyword.merge(config, [
-          algorithm: :sha256,
-          secret: System.get_env("PBKDF2_SECRET")
-        ])
-
-        {:ok, config}
-      end
-  """
-  @callback init(config :: Keyword.t()) :: {:ok, Keyword.t()} | {:error, any}
-
-  @doc false
-  defmacro __using__(opts) do
-    otp_app = Keyword.fetch!(opts, :otp_app)
-
-    quote do
-      @behaviour Cloak.Fields.PBKDF2
-      @behaviour Ecto.Type
-      @algorithms ~w[
-        md4
-        md5
-        ripemd160
-        sha
-        sha224
-        sha256
-        sha384
-        sha512
-      ]a
-      @sizes [16, 32, 64, 128]
-
-      @impl Cloak.Fields.PBKDF2
-      def init(config) do
-        defaults = [algorithm: :sha256, iterations: 10_000, size: 32]
-
-        {:ok, defaults |> Keyword.merge(config)}
-      end
-
-      @impl Ecto.Type
-      def type, do: :binary
-
-      @impl Ecto.Type
-      def cast(nil), do: {:ok, nil}
-      def cast(value) when is_binary(value), do: {:ok, value}
-      def cast(_value), do: :error
-
-      @impl Ecto.Type
-      def dump(nil), do: {:ok, nil}
-
-      def dump(value) when is_binary(value) do
-        config = build_config()
-        :pbkdf2.pbkdf2({:hmac, config[:algorithm]}, value, config[:secret], config[:size])
-      end
-
-      def dump(_value), do: :error
-
-      @impl Ecto.Type
-      def load(value), do: {:ok, value}
-
-      defoverridable init: 1, type: 0, cast: 1, dump: 1, load: 1
-
-      defp build_config do
-        {:ok, config} =
-          unquote(otp_app)
-          |> Application.get_env(__MODULE__, [])
-          |> init()
-
-        validate_config(config)
-      end
-
-      defp validate_config(config) do
-        unless is_binary(config[:secret]) do
-          secret = inspect(config[:secret])
-
-          raise Cloak.InvalidConfig, "#{secret} is an invalid secret for #{inspect(__MODULE__)}"
+          {:ok, defaults |> Keyword.merge(config)}
         end
 
-        unless config[:algorithm] in @algorithms do
-          algo = inspect(config[:algorithm])
+        @impl Ecto.Type
+        def type, do: :binary
 
-          raise Cloak.InvalidConfig,
-                "#{algo} is an invalid hash algorithm for #{inspect(__MODULE__)}"
+        @impl Ecto.Type
+        def cast(nil), do: {:ok, nil}
+        def cast(value) when is_binary(value), do: {:ok, value}
+        def cast(_value), do: :error
+
+        @impl Ecto.Type
+        def dump(nil), do: {:ok, nil}
+
+        def dump(value) when is_binary(value) do
+          config = build_config()
+          :pbkdf2.pbkdf2({:hmac, config[:algorithm]}, value, config[:secret], config[:size])
         end
 
-        unless is_integer(config[:iterations]) && config[:iterations] > 0 do
-          iterations = inspect(config[:iterations])
+        def dump(_value), do: :error
 
-          raise Cloak.InvalidConfig,
-                "#{iterations} must be a positive integer for #{inspect(__MODULE__)}"
+        @impl Ecto.Type
+        def load(value), do: {:ok, value}
+
+        defoverridable init: 1, type: 0, cast: 1, dump: 1, load: 1
+
+        defp build_config do
+          {:ok, config} =
+            unquote(otp_app)
+            |> Application.get_env(__MODULE__, [])
+            |> init()
+
+          validate_config(config)
         end
 
-        unless config[:size] in @sizes do
-          size = inspect(config[:size])
+        defp validate_config(config) do
+          unless is_binary(config[:secret]) do
+            secret = inspect(config[:secret])
 
-          raise Cloak.InvalidConfig,
-                "#{size} should be one of 16, 32, 64, or 128 for #{inspect(__MODULE__)}"
+            raise Cloak.InvalidConfig, "#{secret} is an invalid secret for #{inspect(__MODULE__)}"
+          end
+
+          unless config[:algorithm] in @algorithms do
+            algo = inspect(config[:algorithm])
+
+            raise Cloak.InvalidConfig,
+                  "#{algo} is an invalid hash algorithm for #{inspect(__MODULE__)}"
+          end
+
+          unless is_integer(config[:iterations]) && config[:iterations] > 0 do
+            iterations = inspect(config[:iterations])
+
+            raise Cloak.InvalidConfig,
+                  "#{iterations} must be a positive integer for #{inspect(__MODULE__)}"
+          end
+
+          unless config[:size] in @sizes do
+            size = inspect(config[:size])
+
+            raise Cloak.InvalidConfig,
+              "#{size} should be one of 16, 32, 64, or 128 for #{inspect(__MODULE__)}"
+          end
+
+          config
         end
-
-        config
       end
     end
   end

--- a/lib/cloak/fields/pbkdf2.ex
+++ b/lib/cloak/fields/pbkdf2.ex
@@ -1,0 +1,193 @@
+defmodule Cloak.Fields.PBKDF2 do
+  @moduledoc """
+  A custom `Ecto.Type` for deriving a key for fields using
+  [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2).
+
+  PBKDF2 is **more secure** than `Cloak.Fields.HMAC` and
+  `Cloak.Fields.SHA256` because it uses [key
+  stretching](https://en.wikipedia.org/wiki/Key_stretching) to increase the
+  amount of time to compute hashes. This slows down brute-force attacks.
+
+  ## Why
+
+  If you store a hash of a field's value, you can then query on it as a proxy
+  for an encrypted field. This works because PBKDF2 is deterministic and
+  always results in the same value, while secure encryption does not. Be
+  warned, however, that hashing will expose which fields have the same value,
+  because they will contain the same hash.
+
+  ## Configuration
+
+  Create a `PBKDF2` field in your project:
+
+      defmodule MyApp.Hashed.PBKDF2 do
+        use Cloak.Fields.PBKDF2, otp_app: :my_app
+      end
+
+  Then, configure it with a `:secret`, an `:algorithm`, the maximum `:size`
+  of the stored key (in bytes), and a number of `:iterations`, either using
+  mix configuration:
+
+      config :my_app, MyApp.Hashed.PBKDF2,
+        algorithm: :sha256,
+        iterations: 10_000,
+        secret: "secret"
+
+  Or using the `init/1` callback to fetch configuration at runtime:
+
+      defmodule MyApp.Hashed.PBKDF2 do
+        use Cloak.Fields.PBKDF2, otp_app: :my_app
+
+        @impl Cloak.Fields.PBKDF2
+        def init(config) do
+          config = Keyword.merge(config, [
+            algorithm: :sha256,
+            iterations: 10_000,
+            secret: System.get_env("PBKDF2_SECRET")
+          ])
+
+          {:ok, config}
+        end
+      end
+
+  ## Usage
+
+  Create the hash field with the type `:binary`. Add it to your schema
+  definition like this:
+
+      schema "table" do
+        field :field_name, MyApp.Encrypted.Binary
+        field :field_name_hash, MyApp.Hashed.PBKDF2
+      end
+
+  Ensure that the hash is updated whenever the target field changes with the
+  `put_change/3` function:
+
+      def changeset(struct, attrs \\\\ %{}) do
+        struct
+        |> cast(attrs, [:field_name, :field_name_hash])
+        |> put_hashed_fields()
+      end
+
+      defp put_hashed_fields(changeset) do
+        changeset
+        |> put_change(:field_name_hash, get_field(changeset, :field_name))
+      end
+
+  Query the Repo using the `:field_name_hash` in any place you would typically
+  query by `:field_name`.
+
+      user = Repo.get_by(User, email_hash: "user@email.com")
+  """
+
+  @typedoc "Digest algorithms supported by Cloak.Field.PBKDF2"
+  @type algorithms :: :md4 | :md5 | :ripemd160 | :sha | :sha224 | :sha256 | :sha384 | :sha512
+
+  @doc """
+  Configures the `PBKDF2` field using runtime information.
+
+  ## Example
+
+      @impl Cloak.Fields.PBKDF2
+      def init(config) do
+        config = Keyword.merge(config, [
+          algorithm: :sha256,
+          secret: System.get_env("PBKDF2_SECRET")
+        ])
+
+        {:ok, config}
+      end
+  """
+  @callback init(config :: Keyword.t()) :: {:ok, Keyword.t()} | {:error, any}
+
+  @doc false
+  defmacro __using__(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    quote do
+      @behaviour Cloak.Fields.PBKDF2
+      @behaviour Ecto.Type
+      @algorithms ~w[
+        md4
+        md5
+        ripemd160
+        sha
+        sha224
+        sha256
+        sha384
+        sha512
+      ]a
+      @sizes [16, 32, 64, 128]
+
+      @impl Cloak.Fields.PBKDF2
+      def init(config) do
+        defaults = [algorithm: :sha256, iterations: 10_000, size: 32]
+
+        {:ok, defaults |> Keyword.merge(config)}
+      end
+
+      @impl Ecto.Type
+      def type, do: :binary
+
+      @impl Ecto.Type
+      def cast(nil), do: {:ok, nil}
+      def cast(value) when is_binary(value), do: {:ok, value}
+      def cast(_value), do: :error
+
+      @impl Ecto.Type
+      def dump(nil), do: {:ok, nil}
+
+      def dump(value) when is_binary(value) do
+        config = build_config()
+        :pbkdf2.pbkdf2({:hmac, config[:algorithm]}, value, config[:secret], config[:size])
+      end
+
+      def dump(_value), do: :error
+
+      @impl Ecto.Type
+      def load(value), do: {:ok, value}
+
+      defoverridable init: 1, type: 0, cast: 1, dump: 1, load: 1
+
+      defp build_config do
+        {:ok, config} =
+          unquote(otp_app)
+          |> Application.get_env(__MODULE__, [])
+          |> init()
+
+        validate_config(config)
+      end
+
+      defp validate_config(config) do
+        unless is_binary(config[:secret]) do
+          secret = inspect(config[:secret])
+
+          raise Cloak.InvalidConfig, "#{secret} is an invalid secret for #{inspect(__MODULE__)}"
+        end
+
+        unless config[:algorithm] in @algorithms do
+          algo = inspect(config[:algorithm])
+
+          raise Cloak.InvalidConfig,
+                "#{algo} is an invalid hash algorithm for #{inspect(__MODULE__)}"
+        end
+
+        unless is_integer(config[:iterations]) && config[:iterations] > 0 do
+          iterations = inspect(config[:iterations])
+
+          raise Cloak.InvalidConfig,
+                "#{iterations} must be a positive integer for #{inspect(__MODULE__)}"
+        end
+
+        unless config[:size] in @sizes do
+          size = inspect(config[:size])
+
+          raise Cloak.InvalidConfig,
+                "#{size} should be one of 16, 32, 64, or 128 for #{inspect(__MODULE__)}"
+        end
+
+        config
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Cloak.Mixfile do
     [
       {:ecto, ">= 1.0.0"},
       {:flow, "~> 0.13.0"},
+      {:pbkdf2, "~> 2.0", optional: true},
       {:poison, ">= 1.5.0", optional: true},
       {:excoveralls, "~> 0.8", only: :test},
       {:postgrex, ">= 0.0.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,7 @@
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "pbkdf2": {:hex, :pbkdf2, "2.0.0", "11c23279fded5c0027ab3996cfae77805521d7ef4babde2bd7ec04a9086cf499", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/cloak/fields/pbkdf2_test.exs
+++ b/test/cloak/fields/pbkdf2_test.exs
@@ -1,0 +1,60 @@
+defmodule Cloak.Fields.PBKDF2Test do
+  use ExUnit.Case
+
+  defmodule Field do
+    use Cloak.Fields.PBKDF2, otp_app: :cloak
+
+    @impl true
+    def init(_config) do
+      {:ok, [algorithm: :sha256, iterations: 1, secret: "secret", size: 32]}
+    end
+  end
+
+  @invalid_types [%{}, [], 123, 123.22]
+
+  describe ".type/0" do
+    test "returns :binary" do
+      assert :binary == Field.type()
+    end
+  end
+
+  describe ".cast/1" do
+    test "leaves nil unchanged" do
+      assert {:ok, nil} = Field.cast(nil)
+    end
+
+    test "leaves binary values unchanged" do
+      assert {:ok, "value"} = Field.cast("value")
+      assert {:ok, <<1>>} = Field.cast(<<1>>)
+    end
+
+    test "returns :error for all other types" do
+      for type <- @invalid_types do
+        assert :error = Field.cast(type)
+      end
+    end
+  end
+
+  describe ".dump/1" do
+    test "returns nils unchanged" do
+      assert {:ok, nil} = Field.dump(nil)
+    end
+
+    test "derives a key for binaries" do
+      assert {:ok, key} = Field.dump("value")
+      assert 32 == byte_size(key)
+    end
+
+    test "returns :error for all other types" do
+      for type <- @invalid_types do
+        assert :error = Field.dump(type)
+      end
+    end
+  end
+
+  describe ".load/1" do
+    test "returns value unchanged" do
+      assert {:ok, "value"} = Field.load("value")
+    end
+  end
+end


### PR DESCRIPTION
For very sensitive information (Social Security numbers, tax identification numbers, or other ostensibly unique numbers assigned to people), it is a good idea to use a key stretching algorithm for the blind index to make it harder to brute force the hashed values. PBKDF2 is a key stretching algorithm that accomplishes this.