### PR TITLE
Candidate for migration that supports binary_id

### DIFF
--- a/lib/cloak/migrator.ex
+++ b/lib/cloak/migrator.ex
@@ -8,6 +8,14 @@ defmodule Cloak.Migrator do
   def migrate(repo, schema) when is_atom(repo) and is_atom(schema) do
     validate(repo, schema)
 
+    pk_types =
+      schema.__schema__(:primary_key)
+      |> Enum.map(fn k -> schema.__schema__(:type, k) end)
+
+    migrate_schema(repo, schema, pk_types)
+  end
+
+  defp migrate_schema(repo, schema, [:id]) do
     min_id = repo.aggregate(schema, :min, :id)
     max_id = repo.aggregate(schema, :max, :id)
     fields = cloak_fields(schema)
@@ -16,6 +24,19 @@ defmodule Cloak.Migrator do
     |> Flow.from_enumerable(stages: System.schedulers_online())
     |> Flow.map(&migrate_row(&1, repo, schema, fields))
     |> Flow.run()
+  end
+
+  defp migrate_schema(repo, schema, [:binary_id]) do
+    fields = cloak_fields(schema)
+
+    repo.all(from(s in schema, select: s.id))
+    |> Flow.from_enumerable(stages: System.schedulers_online())
+    |> Flow.map(&migrate_row(&1, repo, schema, fields))
+    |> Flow.run()
+  end
+
+  defp migrate_schema(_repo, schema, _pk_types) do
+    raise ArgumentError, "#{inspect(schema)} has a composite primary key"
   end
 
   defp migrate_row(id, repo, schema, fields) do


### PR DESCRIPTION
This is a pretty meager pull request, and I haven't written tests for this. Even so, this is a potential approach to supporting :binary_id PKs as well as composite keys in the future.

Given Ecto's limitations with streaming via GenStage, this is not an optimized solution, but it's a starting point that can be expanded. Note that it provides a mechanism for more complex composite keys in the future as well, which are also currently not supported.