### PR TITLE
Migration task succeeds on empty table

### DIFF
--- a/lib/cloak/migrator.ex
+++ b/lib/cloak/migrator.ex
@@ -9,6 +9,13 @@ defmodule Cloak.Migrator do
   def migrate(repo, schema) when is_atom(repo) and is_atom(schema) do
     validate(repo, schema)
 
+    case repo.aggregate(schema, :count, :id) do
+      0 -> {:ok, "Empty schema. No data migrated."}
+      _ -> migrate_schema_with_data(repo, schema)
+    end
+  end
+
+  defp migrate_schema_with_data(repo, schema) do
     fields = cloak_fields(schema)
 
     repo

--- a/lib/cloak/migrator.ex
+++ b/lib/cloak/migrator.ex
@@ -9,7 +9,9 @@ defmodule Cloak.Migrator do
   def migrate(repo, schema) when is_atom(repo) and is_atom(schema) do
     validate(repo, schema)
 
-    case repo.aggregate(schema, :count, :id) do
+    [primary_key | _] = schema.__schema__(:primary_key)
+
+    case repo.aggregate(schema, :count, primary_key) do
       0 -> {:ok, "Empty schema. No data migrated."}
       _ -> migrate_schema_with_data(repo, schema)
     end

--- a/lib/cloak/migrator.ex
+++ b/lib/cloak/migrator.ex
@@ -12,7 +12,7 @@ defmodule Cloak.Migrator do
     [primary_key | _] = schema.__schema__(:primary_key)
 
     case repo.aggregate(schema, :count, primary_key) do
-      0 -> {:ok, "Empty schema. No data migrated."}
+      0 -> :ok
       _ -> migrate_schema_with_data(repo, schema)
     end
   end

--- a/test/cloak/migrator_test.exs
+++ b/test/cloak/migrator_test.exs
@@ -21,7 +21,8 @@ defmodule Cloak.MigratorTest do
     Migrator.migrate(Repo, User)
 
     updated =
-      from(u in "users",
+      from(
+        u in "users",
         where: u.id == ^context[:user].id,
         select: [:id, :name, :email, :email_hash]
       )
@@ -96,6 +97,12 @@ defmodule Cloak.MigratorTest do
 
       assert io =~ "__cloak_cursor_fields__", "Did not call __cloak_cursor_fields__ on schema!"
       assert titles == [{:ok, @post_title}], "Not all titles were migrated!"
+    end
+  end
+
+  describe ".migrate/2 on a schema with no rows" do
+    test "alerts no data available to migrate" do
+      assert match?({:ok, "Empty schema. No data migrated."}, Migrator.migrate(Repo, User))
     end
   end
 

--- a/test/cloak/migrator_test.exs
+++ b/test/cloak/migrator_test.exs
@@ -100,12 +100,6 @@ defmodule Cloak.MigratorTest do
     end
   end
 
-  describe ".migrate/2 on a schema with no rows" do
-    test "alerts no data available to migrate" do
-      assert match?({:ok, "Empty schema. No data migrated."}, Migrator.migrate(Repo, User))
-    end
-  end
-
   defp decrypt(ciphertext, label) do
     {cipher, opts} = Application.get_env(:cloak, Vault)[:ciphers][label]
     cipher.decrypt(ciphertext, opts)


### PR DESCRIPTION
This functionality appears to have been introduced in
cdeae97c69f7c54aeadf0921db30dc411d7a9938; however, it looks like it was
removed as part of the refactor to use a cursor for IDs rather than
requiring numeric IDs in 01946dcd39fe96be9b79c1d095fc71ec311cfd93.

With this change, if the migrator is passed a schema that is linked to
an empty table, an error is no longer raised. Instead, the migration is
not attempted, and the function returns that the migration completed.

This does have the impact of changing the return value of the function
in this scenario. Rather than the `:ok` it otherwise returns, instead
it returns a tuple `{:ok, message}`, where the message includes
information about why no migration took place. It doesn't appear that
the return value of this function is used; however, this technically
breaks the public API in the scenario where the schema has no data.

While that tuple is not surfaced to the end-user as part of this effort,
it has the impact of making testing this change easier by making the
impact observable for something that would have no side-effect
(given that the migration does nothing, as there's no data to migrate).
Presumably this could be helpful to callers as well.