### PR TITLE
[#81] Fix migrator with embedded schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ script:
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report
+addons:
+  postgresql: "9.4"

--- a/lib/cloak/migrator.ex
+++ b/lib/cloak/migrator.ex
@@ -51,12 +51,18 @@ defmodule Cloak.Migrator do
     |> Enum.map(fn field ->
       {field, schema.__schema__(:type, field)}
     end)
-    |> Enum.filter(fn {_field, type} ->
-      Code.ensure_loaded?(type) && function_exported?(type, :__cloak__, 0)
-    end)
+    |> Enum.filter(&cloak_field?/1)
     |> Enum.map(fn {field, _type} ->
       field
     end)
+  end
+
+  defp cloak_field?({_field, {:embed, %Ecto.Embedded{}}}) do
+    false
+  end
+
+  defp cloak_field?({_field, type}) do
+    Code.ensure_loaded?(type) && function_exported?(type, :__cloak__, 0)
   end
 
   defp validate(repo, schema) do

--- a/test/cloak/migrator_test.exs
+++ b/test/cloak/migrator_test.exs
@@ -75,7 +75,17 @@ defmodule Cloak.MigratorTest do
     setup do
       now = DateTime.utc_now()
       encrypted_title = Cloak.TestVault.encrypt!(@post_title, :secondary)
-      posts = for _ <- 1..500, do: %{title: encrypted_title, inserted_at: now, updated_at: now}
+
+      posts =
+        for _ <- 1..500 do
+          %{
+            title: encrypted_title,
+            comments: [%{author: "Daniel", body: "Comment"}],
+            inserted_at: now,
+            updated_at: now
+          }
+        end
+
       Repo.insert_all("posts", posts)
 
       :ok

--- a/test/support/comment.ex
+++ b/test/support/comment.ex
@@ -1,0 +1,8 @@
+defmodule Cloak.TestComment do
+  use Ecto.Schema
+
+  embedded_schema do
+    field(:author, :string)
+    field(:body, :string)
+  end
+end

--- a/test/support/migrations/20180915035851_create_posts.exs
+++ b/test/support/migrations/20180915035851_create_posts.exs
@@ -7,6 +7,7 @@ defmodule Cloak.TestRepo.Migrations.CreatePosts do
     create table(:posts, primary_key: false) do
       add(:id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()"))
       add(:title, :binary)
+      add(:comments, {:array, :map})
       timestamps(type: :utc_datetime)
     end
 

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -7,6 +7,7 @@ defmodule Cloak.TestPost do
 
   schema "posts" do
     field(:title, Cloak.Test.Encrypted.Binary)
+    embeds_many(:comments, Cloak.TestComment)
     timestamps(type: :utc_datetime)
   end
 


### PR DESCRIPTION
The migrator will no longer fail if your schema contains embedded
schemas, so this fixes #81.

However, Cloak fields will not encrypt in embedded schemas,
because Ecto does not call `dump` callbacks on custom Ecto types in
embedded schemas. I'm going to add an issue to investigate further.