### PR TITLE
OTP 24 support

### DIFF
--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -35,9 +35,9 @@ defmodule Cloak.Ciphers.AES.CTR do
     tag = Keyword.fetch!(opts, :tag)
 
     iv = :crypto.strong_rand_bytes(16)
-    state = :crypto.stream_init(:aes_ctr, key, iv)
+    state = do_init(key, iv, true)
 
-    {_state, ciphertext} = :crypto.stream_encrypt(state, to_string(plaintext))
+    ciphertext = do_encrypt(state, to_string(plaintext))
     {:ok, Encoder.encode(tag) <> iv <> ciphertext}
   end
 
@@ -62,8 +62,8 @@ defmodule Cloak.Ciphers.AES.CTR do
     if can_decrypt?(ciphertext, opts) do
       key = Keyword.fetch!(opts, :key)
       %{remainder: <<iv::binary-16, ciphertext::binary>>} = Decoder.decode(ciphertext)
-      state = :crypto.stream_init(:aes_ctr, key, iv)
-      {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
+      state = do_init(key, iv, false)
+      plaintext = do_decrypt(state, ciphertext)
       {:ok, plaintext}
     else
       :error
@@ -84,6 +84,33 @@ defmodule Cloak.Ciphers.AES.CTR do
 
       _other ->
         false
+    end
+  end
+
+  # TODO: remove this once support for Erlang/OTP 21 is dropped
+  defp do_init(key, iv, encoder?) do
+    if System.otp_release() >= "22" do
+      :crypto.crypto_init(:aes_ctr, key, iv, encoder?)
+    else
+      :crypto.stream_init(:aes_ctr, key, iv)
+    end
+  end
+
+  defp do_encrypt(state, plaintext) do
+    if System.otp_release() >= "22" do
+      :crypto.crypto_update(state, plaintext)
+    else
+      {_state, cyphertext} = :crypto.stream_encrypt(state, plaintext)
+      cyphertext
+    end
+  end
+
+  defp do_decrypt(state, ciphertext) do
+    if System.otp_release() >= "22" do
+      :crypto.crypto_update(state, ciphertext)
+    else
+      {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
+      plaintext
     end
   end
 end

--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -88,27 +88,29 @@ defmodule Cloak.Ciphers.AES.CTR do
   end
 
   # TODO: remove this once support for Erlang/OTP 21 is dropped
-  defp do_init(key, iv, encoder?) do
-    if System.otp_release() >= "22" do
-      :crypto.crypto_init(:aes_ctr, key, iv, encoder?)
-    else
+  if System.otp_release() >= "22" do
+    defp do_init(key, iv, encoder?) do
+      :crypto.crypto_init(:aes_256_ctr, key, iv, encoder?)
+    end
+
+    defp do_encrypt(state, plaintext) do
+      :crypto.crypto_update(state, plaintext)
+    end
+
+    defp do_decrypt(state, ciphertext) do
+      :crypto.crypto_update(state, ciphertext)
+    end
+  else
+    defp do_init(key, iv, _) do
       :crypto.stream_init(:aes_ctr, key, iv)
     end
-  end
 
-  defp do_encrypt(state, plaintext) do
-    if System.otp_release() >= "22" do
-      :crypto.crypto_update(state, plaintext)
-    else
+    defp do_encrypt(state, plaintext) do
       {_state, cyphertext} = :crypto.stream_encrypt(state, plaintext)
       cyphertext
     end
-  end
 
-  defp do_decrypt(state, ciphertext) do
-    if System.otp_release() >= "22" do
-      :crypto.crypto_update(state, ciphertext)
-    else
+    defp do_decrypt(state, ciphertext) do
       {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
       plaintext
     end

--- a/lib/cloak/ciphers/aes_gcm.ex
+++ b/lib/cloak/ciphers/aes_gcm.ex
@@ -43,8 +43,17 @@ defmodule Cloak.Ciphers.AES.GCM do
     iv_length = Keyword.get(opts, :iv_length, @default_iv_length)
     iv = :crypto.strong_rand_bytes(iv_length)
 
-    {ciphertext, ciphertag} = :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, plaintext})
+    {ciphertext, ciphertag} = do_encrypt(key, iv, plaintext)
     {:ok, Encoder.encode(tag) <> iv <> ciphertag <> ciphertext}
+  end
+
+  # TODO: remove this once support for Erlang/OTP 21 is dropped
+  defp do_encrypt(key, iv, plaintext) do
+    if System.otp_release() >= "22" do
+      :crypto.crypto_one_time_aead(:aes_gcm, key, iv, plaintext, @aad, true)
+    else
+      :crypto.block_encrypt(:aes_gcm, key, iv, {@aad, plaintext})
+    end
   end
 
   @doc """
@@ -60,9 +69,18 @@ defmodule Cloak.Ciphers.AES.GCM do
       %{remainder: <<iv::binary-size(iv_length), ciphertag::binary-16, ciphertext::binary>>} =
         Decoder.decode(ciphertext)
 
-      {:ok, :crypto.block_decrypt(:aes_gcm, key, iv, {@aad, ciphertext, ciphertag})}
+      {:ok, do_decrypt(key, iv, ciphertext, ciphertag)}
     else
       :error
+    end
+  end
+
+  # TODO: remove this once support for Erlang/OTP 21 is dropped
+  defp do_decrypt(key, iv, ciphertext, ciphertag) do
+    if System.otp_release() >= "22" do
+      :crypto.crypto_one_time_aead(:aes_gcm, key, iv, ciphertext, @aad, ciphertag, false)
+    else
+      :crypto.block_decrypt(:aes_gcm, key, iv, {@aad, ciphertext, ciphertag})
     end
   end
 


### PR DESCRIPTION
Adds support for Erlang/OTP 24.

I tested on OTP 24 only (OTP 21 isn't compiling on my machine), and I think it is important to test it on OTP 21 too. IMO it would be good if both versions were tested on CI.