### PR TITLE
Erlang 24 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ MyApp.Vault.decrypt(ciphertext)
 
 ```elixir
 "plaintext"
-|> MyApp.Vault.encrypt!(:aes_gcm)
+|> MyApp.Vault.encrypt!(:aes_256_gcm)
 |> MyApp.Vault.decrypt!()
-|> MyApp.Vault.encrypt!(:aes_ctr)
+|> MyApp.Vault.encrypt!(:aes_256_ctr)
 |> MyApp.Vault.decrypt!()
 # => "plaintext"
 ```

--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -7,6 +7,7 @@ defmodule Cloak.Ciphers.AES.CTR do
   @behaviour Cloak.Cipher
 
   alias Cloak.Tags.{Encoder, Decoder}
+  alias Cloak.Crypto
 
   @doc """
   Callback implementation for `Cloak.Cipher`. Encrypts a value using
@@ -34,10 +35,8 @@ defmodule Cloak.Ciphers.AES.CTR do
     key = Keyword.fetch!(opts, :key)
     tag = Keyword.fetch!(opts, :tag)
 
-    iv = :crypto.strong_rand_bytes(16)
-    state = :crypto.stream_init(:aes_ctr, key, iv)
-
-    {_state, ciphertext} = :crypto.stream_encrypt(state, to_string(plaintext))
+    iv = Crypto.strong_rand_bytes(16)
+    ciphertext = Crypto.encrypt_one_time(:aes_ctr, key, iv, to_string(plaintext))
     {:ok, Encoder.encode(tag) <> iv <> ciphertext}
   end
 
@@ -62,8 +61,7 @@ defmodule Cloak.Ciphers.AES.CTR do
     if can_decrypt?(ciphertext, opts) do
       key = Keyword.fetch!(opts, :key)
       %{remainder: <<iv::binary-16, ciphertext::binary>>} = Decoder.decode(ciphertext)
-      state = :crypto.stream_init(:aes_ctr, key, iv)
-      {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
+      plaintext = Crypto.decrypt_one_time(:aes_ctr, key, iv, ciphertext)
       {:ok, plaintext}
     else
       :error

--- a/lib/cloak/ciphers/aes_ctr.ex
+++ b/lib/cloak/ciphers/aes_ctr.ex
@@ -9,6 +9,8 @@ defmodule Cloak.Ciphers.AES.CTR do
   alias Cloak.Tags.{Encoder, Decoder}
   alias Cloak.Crypto
 
+  @cipher Crypto.map_cipher(:aes_256_ctr)
+
   @doc """
   Callback implementation for `Cloak.Cipher`. Encrypts a value using
   AES in CTR mode.
@@ -34,9 +36,8 @@ defmodule Cloak.Ciphers.AES.CTR do
   def encrypt(plaintext, opts) when is_binary(plaintext) do
     key = Keyword.fetch!(opts, :key)
     tag = Keyword.fetch!(opts, :tag)
-
     iv = Crypto.strong_rand_bytes(16)
-    ciphertext = Crypto.encrypt_one_time(:aes_ctr, key, iv, to_string(plaintext))
+    ciphertext = Crypto.encrypt_one_time(@cipher, key, iv, to_string(plaintext))
     {:ok, Encoder.encode(tag) <> iv <> ciphertext}
   end
 
@@ -61,7 +62,7 @@ defmodule Cloak.Ciphers.AES.CTR do
     if can_decrypt?(ciphertext, opts) do
       key = Keyword.fetch!(opts, :key)
       %{remainder: <<iv::binary-16, ciphertext::binary>>} = Decoder.decode(ciphertext)
-      plaintext = Crypto.decrypt_one_time(:aes_ctr, key, iv, ciphertext)
+      plaintext = Crypto.decrypt_one_time(@cipher, key, iv, ciphertext)
       {:ok, plaintext}
     else
       :error

--- a/lib/cloak/ciphers/aes_gcm.ex
+++ b/lib/cloak/ciphers/aes_gcm.ex
@@ -5,11 +5,13 @@ defmodule Cloak.Ciphers.AES.GCM do
   """
 
   @behaviour Cloak.Cipher
-  @aad "AES256GCM"
-  @default_iv_length 16
 
   alias Cloak.Tags.{Encoder, Decoder}
   alias Cloak.Crypto
+
+  @aad "AES256GCM"
+  @default_iv_length 16
+  @cipher Crypto.map_cipher(:aes_256_gcm)
 
   @doc """
   Callback implementation for `Cloak.Cipher`. Encrypts a value using
@@ -42,8 +44,7 @@ defmodule Cloak.Ciphers.AES.GCM do
     tag = Keyword.fetch!(opts, :tag)
     iv_length = Keyword.get(opts, :iv_length, @default_iv_length)
     iv = Crypto.strong_rand_bytes(iv_length)
-
-    {ciphertext, ciphertag} = Crypto.encrypt_one_time_aead(:aes_gcm, key, iv, @aad, plaintext)
+    {ciphertext, ciphertag} = Crypto.encrypt_one_time_aead(@cipher, key, iv, @aad, plaintext)
 
     {:ok, Encoder.encode(tag) <> iv <> ciphertag <> ciphertext}
   end
@@ -60,8 +61,7 @@ defmodule Cloak.Ciphers.AES.GCM do
 
       %{remainder: <<iv::binary-size(iv_length), ciphertag::binary-16, ciphertext::binary>>} =
         Decoder.decode(ciphertext)
-
-      plaintext = Crypto.decrypt_one_time_aead(:aes_gcm, key, iv, @aad, ciphertext, ciphertag)
+      plaintext = Crypto.decrypt_one_time_aead(@cipher, key, iv, @aad, ciphertext, ciphertag)
       {:ok, plaintext}
     else
       :error

--- a/lib/cloak/ciphers/aes_gcm.ex
+++ b/lib/cloak/ciphers/aes_gcm.ex
@@ -61,6 +61,7 @@ defmodule Cloak.Ciphers.AES.GCM do
 
       %{remainder: <<iv::binary-size(iv_length), ciphertag::binary-16, ciphertext::binary>>} =
         Decoder.decode(ciphertext)
+
       plaintext = Crypto.decrypt_one_time_aead(@cipher, key, iv, @aad, ciphertext, ciphertag)
       {:ok, plaintext}
     else

--- a/lib/cloak/ciphers/deprecated/aes_ctr.ex
+++ b/lib/cloak/ciphers/deprecated/aes_ctr.ex
@@ -20,9 +20,11 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTR do
   See the [Upgrading from 0.6.x](0.6.x_to_0.7.x.html) guide for usage.
   """
 
+  @behaviour Cloak.Cipher
+
   alias Cloak.Crypto
 
-  @behaviour Cloak.Cipher
+  @cipher Crypto.map_cipher(:aes_256_ctr)
 
   @deprecated "Use Cloak.Ciphers.AES.CTR.encrypt/2 instead. This call will raise an error."
   @impl Cloak.Cipher
@@ -38,7 +40,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTR do
     with true <- can_decrypt?(ciphertext, opts),
          <<iv::binary-16, ciphertext::binary>> <-
            String.replace_leading(ciphertext, tag(opts), <<>>) do
-      plaintext = Crypto.decrypt_one_time(:aes_ctr, key, iv, ciphertext)
+      plaintext = Crypto.decrypt_one_time(@cipher, key, iv, ciphertext)
       {:ok, plaintext}
     else
       _other ->

--- a/lib/cloak/ciphers/deprecated/aes_ctr.ex
+++ b/lib/cloak/ciphers/deprecated/aes_ctr.ex
@@ -20,6 +20,8 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTR do
   See the [Upgrading from 0.6.x](0.6.x_to_0.7.x.html) guide for usage.
   """
 
+  alias Cloak.Crypto
+
   @behaviour Cloak.Cipher
 
   @deprecated "Use Cloak.Ciphers.AES.CTR.encrypt/2 instead. This call will raise an error."
@@ -36,8 +38,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTR do
     with true <- can_decrypt?(ciphertext, opts),
          <<iv::binary-16, ciphertext::binary>> <-
            String.replace_leading(ciphertext, tag(opts), <<>>) do
-      state = :crypto.stream_init(:aes_ctr, key, iv)
-      {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
+      plaintext = Crypto.decrypt_one_time(:aes_ctr, key, iv, ciphertext)
       {:ok, plaintext}
     else
       _other ->

--- a/lib/cloak/ciphers/deprecated/aes_gcm.ex
+++ b/lib/cloak/ciphers/deprecated/aes_gcm.ex
@@ -19,12 +19,13 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCM do
 
   See the [Upgrading from 0.6.x](0.6.x_to_0.7.x.html) guide for usage.
   """
-
   @behaviour Cloak.Cipher
-  @aad "AES256GCM"
 
   alias Cloak.Tags.Decoder
   alias Cloak.Crypto
+
+  @cipher Crypto.map_cipher(:aes_256_gcm)
+  @aad "AES256GCM"
 
   @deprecated "Use Cloak.Ciphers.AES.GCM.encrypt/2 instead. This call will raise an error."
   @impl Cloak.Cipher
@@ -38,7 +39,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCM do
     key = Keyword.fetch!(opts, :key)
 
     with <<iv::binary-16, ciphertag::binary-16, ciphertext::binary>> <- decode(ciphertext, opts) do
-      plaintext = Crypto.decrypt_one_time_aead(:aes_gcm, key, iv, @aad, ciphertext, ciphertag)
+      plaintext = Crypto.decrypt_one_time_aead(@cipher, key, iv, @aad, ciphertext, ciphertag)
       {:ok, plaintext}
     else
       _other ->

--- a/lib/cloak/ciphers/deprecated/aes_gcm.ex
+++ b/lib/cloak/ciphers/deprecated/aes_gcm.ex
@@ -24,6 +24,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCM do
   @aad "AES256GCM"
 
   alias Cloak.Tags.Decoder
+  alias Cloak.Crypto
 
   @deprecated "Use Cloak.Ciphers.AES.GCM.encrypt/2 instead. This call will raise an error."
   @impl Cloak.Cipher
@@ -37,7 +38,8 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCM do
     key = Keyword.fetch!(opts, :key)
 
     with <<iv::binary-16, ciphertag::binary-16, ciphertext::binary>> <- decode(ciphertext, opts) do
-      {:ok, :crypto.block_decrypt(:aes_gcm, key, iv, {@aad, ciphertext, ciphertag})}
+      plaintext = Crypto.decrypt_one_time_aead(:aes_gcm, key, iv, @aad, ciphertext, ciphertag)
+      {:ok, plaintext}
     else
       _other ->
         :error

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -10,7 +10,7 @@ defmodule Cloak.Crypto do
     :crypto.strong_rand_bytes(num)
   end
 
-  if System.otp_release() >= "22" do
+  if System.otp_release() >= "24" do
     def encrypt_one_time(cipher, key, iv, plaintext) do
       :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: true)
     end
@@ -25,6 +25,26 @@ defmodule Cloak.Crypto do
 
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
       :crypto.crypto_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag, false)
+    end
+  else
+    def encrypt_one_time(cipher, key, iv, plaintext) do
+      state = :crypto.stream_init(cipher, key, iv)
+      {_state, ciphertext} = :crypto.stream_encrypt(state, plaintext)
+      ciphertext
+    end
+
+    def decrypt_one_time(cipher, key, iv, ciphertext) do
+      state = :crypto.stream_init(cipher, key, iv)
+      {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
+      plaintext
+    end
+
+    def encrypt_one_time_aead(cipher, key, iv, aad, plaintext) do
+      :crypto.block_encrypt(cipher, key, iv, {aad, plaintext})
+    end
+
+    def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
+      :crypto.block_decrypt(cipher, key, iv, {aad, ciphertext, ciphertag})
     end
   end
 end

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -10,7 +10,7 @@ defmodule Cloak.Crypto do
     :crypto.strong_rand_bytes(num)
   end
 
-  if System.otp_release() >= "24" do
+  if System.otp_release() >= "22" do
     @impl Cloak.Crypto.Interface
     def encrypt_one_time(cipher, key, iv, plaintext) do
       :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: true)
@@ -30,7 +30,11 @@ defmodule Cloak.Crypto do
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
       :crypto.crypto_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag, false)
     end
+
+    @impl Cloak.Crypto.Interface
+    def map_cipher(cipher), do: cipher
   else
+
     @impl Cloak.Crypto.Interface
     def encrypt_one_time(cipher, key, iv, plaintext) do
       state = :crypto.stream_init(cipher, key, iv)
@@ -54,5 +58,10 @@ defmodule Cloak.Crypto do
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
       :crypto.block_decrypt(cipher, key, iv, {aad, ciphertext, ciphertag})
     end
+
+    @impl Cloak.Crypto.Interface
+    def map_cipher(:aes_256_gcm), do: :aes_gcm
+    def map_cipher(:aes_256_ctr), do: :aes_ctr
+    def map_cipher(cipher), do: cipher
   end
 end

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -1,0 +1,30 @@
+defmodule Cloak.Crypto do
+  @moduledoc ~S"""
+  Interface for mapping encrypt/decrypt actions to different versions of Erlang's `:crypto` API
+  """
+
+  defmodule Interface do
+  end
+
+  def strong_rand_bytes(num) do
+    :crypto.strong_rand_bytes(num)
+  end
+
+  if System.otp_release() >= "22" do
+    def encrypt_one_time(cipher, key, iv, plaintext) do
+      :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: true)
+    end
+
+    def decrypt_one_time(cipher, key, iv, plaintext) do
+      :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: false)
+    end
+
+    def encrypt_one_time_aead(cipher, key, iv, aad, plaintext) do
+      :crypto.crypto_one_time_aead(cipher, key, iv, aad, plaintext, true)
+    end
+
+    def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
+      :crypto.crypto_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag, false)
+    end
+  end
+end

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -23,12 +23,12 @@ defmodule Cloak.Crypto do
 
     @impl Cloak.Crypto.Interface
     def encrypt_one_time_aead(cipher, key, iv, aad, plaintext) do
-      :crypto.crypto_one_time_aead(cipher, key, iv, aad, plaintext, true)
+      :crypto.crypto_one_time_aead(cipher, key, iv, plaintext, aad, true)
     end
 
     @impl Cloak.Crypto.Interface
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
-      :crypto.crypto_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag, false)
+      :crypto.crypto_one_time_aead(cipher, key, iv, ciphertext, aad, ciphertag, false)
     end
 
     @impl Cloak.Crypto.Interface

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -3,46 +3,54 @@ defmodule Cloak.Crypto do
   Interface for mapping encrypt/decrypt actions to different versions of Erlang's `:crypto` API
   """
 
-  defmodule Interface do
-  end
+  @behaviour Cloak.Crypto.Interface
 
+  @impl Cloak.Crypto.Interface
   def strong_rand_bytes(num) do
     :crypto.strong_rand_bytes(num)
   end
 
   if System.otp_release() >= "24" do
+    @impl Cloak.Crypto.Interface
     def encrypt_one_time(cipher, key, iv, plaintext) do
       :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: true)
     end
 
-    def decrypt_one_time(cipher, key, iv, plaintext) do
-      :crypto.crypto_one_time(cipher, key, iv, plaintext, encrypt: false)
+    @impl Cloak.Crypto.Interface
+    def decrypt_one_time(cipher, key, iv, ciphertext) do
+      :crypto.crypto_one_time(cipher, key, iv, ciphertext, encrypt: false)
     end
 
+    @impl Cloak.Crypto.Interface
     def encrypt_one_time_aead(cipher, key, iv, aad, plaintext) do
       :crypto.crypto_one_time_aead(cipher, key, iv, aad, plaintext, true)
     end
 
+    @impl Cloak.Crypto.Interface
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
       :crypto.crypto_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag, false)
     end
   else
+    @impl Cloak.Crypto.Interface
     def encrypt_one_time(cipher, key, iv, plaintext) do
       state = :crypto.stream_init(cipher, key, iv)
       {_state, ciphertext} = :crypto.stream_encrypt(state, plaintext)
       ciphertext
     end
 
+    @impl Cloak.Crypto.Interface
     def decrypt_one_time(cipher, key, iv, ciphertext) do
       state = :crypto.stream_init(cipher, key, iv)
       {_state, plaintext} = :crypto.stream_decrypt(state, ciphertext)
       plaintext
     end
 
+    @impl Cloak.Crypto.Interface
     def encrypt_one_time_aead(cipher, key, iv, aad, plaintext) do
       :crypto.block_encrypt(cipher, key, iv, {aad, plaintext})
     end
 
+    @impl Cloak.Crypto.Interface
     def decrypt_one_time_aead(cipher, key, iv, aad, ciphertext, ciphertag) do
       :crypto.block_decrypt(cipher, key, iv, {aad, ciphertext, ciphertag})
     end

--- a/lib/cloak/crypto.ex
+++ b/lib/cloak/crypto.ex
@@ -34,7 +34,6 @@ defmodule Cloak.Crypto do
     @impl Cloak.Crypto.Interface
     def map_cipher(cipher), do: cipher
   else
-
     @impl Cloak.Crypto.Interface
     def encrypt_one_time(cipher, key, iv, plaintext) do
       state = :crypto.stream_init(cipher, key, iv)

--- a/lib/cloak/crypto/interface.ex
+++ b/lib/cloak/crypto/interface.ex
@@ -5,7 +5,8 @@ defmodule Cloak.Crypto.Interface do
   @callback strong_rand_bytes(non_neg_integer()) :: binary()
   @callback encrypt_one_time(atom(), iodata(), iodata(), iodata()) :: binary()
   @callback decrypt_one_time(atom(), iodata(), iodata(), iodata()) :: binary()
-  @callback encrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata()) :: binary()
+  @callback encrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata()) ::
+              {binary(), binary()}
   @callback decrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata(), iodata()) ::
               binary()
 end

--- a/lib/cloak/crypto/interface.ex
+++ b/lib/cloak/crypto/interface.ex
@@ -9,4 +9,5 @@ defmodule Cloak.Crypto.Interface do
               {binary(), binary()}
   @callback decrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata(), iodata()) ::
               binary()
+  @callback map_cipher(atom()) :: atom()
 end

--- a/lib/cloak/crypto/interface.ex
+++ b/lib/cloak/crypto/interface.ex
@@ -1,0 +1,11 @@
+defmodule Cloak.Crypto.Interface do
+  @doc ~S"""
+  Forward to `:crypto.strong_rand_bytes/1`
+  """
+  @callback strong_rand_bytes(non_neg_integer()) :: binary()
+  @callback encrypt_one_time(atom(), iodata(), iodata(), iodata()) :: binary()
+  @callback decrypt_one_time(atom(), iodata(), iodata(), iodata()) :: binary()
+  @callback encrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata()) :: binary()
+  @callback decrypt_one_time_aead(atom(), iodata(), iodata(), iodata(), iodata(), iodata()) ::
+              binary()
+end

--- a/test/cloak/ciphers/deprecated/aes_ctr_test.exs
+++ b/test/cloak/ciphers/deprecated/aes_ctr_test.exs
@@ -51,8 +51,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTRTest do
   # and key tag were prepended to the iv and ciphertext.
   defp create_ciphertext(_) do
     iv = :crypto.strong_rand_bytes(16)
-    state = :crypto.stream_init(:aes_ctr, @opts[:key], iv)
-    {_state, ciphertext} = :crypto.stream_encrypt(state, "plaintext")
+    ciphertext = Cloak.Crypto.encrypt_one_time(:aes_ctr, @opts[:key], iv, "plaintext")
     [ciphertext: @opts[:module_tag] <> @opts[:tag] <> iv <> ciphertext]
   end
 end

--- a/test/cloak/ciphers/deprecated/aes_ctr_test.exs
+++ b/test/cloak/ciphers/deprecated/aes_ctr_test.exs
@@ -51,7 +51,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.CTRTest do
   # and key tag were prepended to the iv and ciphertext.
   defp create_ciphertext(_) do
     iv = :crypto.strong_rand_bytes(16)
-    ciphertext = Cloak.Crypto.encrypt_one_time(:aes_ctr, @opts[:key], iv, "plaintext")
+    ciphertext = Cloak.Crypto.encrypt_one_time(:aes_256_ctr, @opts[:key], iv, "plaintext")
     [ciphertext: @opts[:module_tag] <> @opts[:tag] <> iv <> ciphertext]
   end
 end

--- a/test/cloak/ciphers/deprecated/aes_gcm_test.exs
+++ b/test/cloak/ciphers/deprecated/aes_gcm_test.exs
@@ -53,7 +53,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCMTest do
     iv = :crypto.strong_rand_bytes(16)
 
     {ciphertext, ciphertag} =
-      :crypto.block_encrypt(:aes_gcm, @opts[:key], iv, {@aad, "plaintext"})
+      Cloak.Crypto.encrypt_one_time_aead(:aes_gcm, @opts[:key], iv, @aad, "plaintext")
 
     [
       ciphertext:

--- a/test/cloak/ciphers/deprecated/aes_gcm_test.exs
+++ b/test/cloak/ciphers/deprecated/aes_gcm_test.exs
@@ -53,7 +53,7 @@ defmodule Cloak.Ciphers.Deprecated.AES.GCMTest do
     iv = :crypto.strong_rand_bytes(16)
 
     {ciphertext, ciphertag} =
-      Cloak.Crypto.encrypt_one_time_aead(:aes_gcm, @opts[:key], iv, @aad, "plaintext")
+      Cloak.Crypto.encrypt_one_time_aead(:aes_256_gcm, @opts[:key], iv, @aad, "plaintext")
 
     [
       ciphertext:


### PR DESCRIPTION
Hi, this PR is not 100% done, but I believe it's a step in the right direction.

I have created a Cloak.Crypto module to intercept the calls to crypto and change based on `System.otp_release/0`
I have created a Cloak.Crypto.Interface behavior to ensure the functions across erlang versions.

There are a couple of things still broken mainly because I am a little out of my depth in the knowledge of ciphers in general.

First, the only version this seems to partially work on is erlang 24 and up. I don't know why but when I set the erlang version to anything less than 24 (i.e. 22  & 23), it gives me an 'Unknown Cipher' error even though the API should be the same.

Second, I am having trouble getting the AES.GCM functions to encrypt properly on erlang 24. I am missing something with the contract that is causing the decrypt to not work.

@danielberkompas if you could give me a push in the right direction it would be greatly appreciated.