### PR TITLE
Fix example code for Base.decode64!

### DIFF
--- a/guides/upgrading/0.6.x_to_0.7.x.md
+++ b/guides/upgrading/0.6.x_to_0.7.x.md
@@ -35,8 +35,8 @@ You would convert it to the following:
 
     config :my_app, MyApp.Vault,
       ciphers: [
-        default: {Cloak.Ciphers.AES.CTR, tag: "AES.V2", key: Base.decode64("...")},
-        retired: {Cloak.Ciphers.Deprecated.AES.CTR, module_tag: "AES", tag: <<1>>, key: Base.decode64("...")}
+        default: {Cloak.Ciphers.AES.CTR, tag: "AES.V2", key: Base.decode64!("...")},
+        retired: {Cloak.Ciphers.Deprecated.AES.CTR, module_tag: "AES", tag: <<1>>, key: Base.decode64!("...")}
       ]
 
 Notice that the `tag: "AES"` became `module_tag: "AES"` in the `:retired`
@@ -131,5 +131,5 @@ Now that the data has been migrated to the new `v0.7` format, you can remove the
 
     config :my_app, MyApp.Vault,
       ciphers: [
-        default: {Cloak.Ciphers.AES.CTR, tag: "AES.V2", key: Base.decode64("...")}
+        default: {Cloak.Ciphers.AES.CTR, tag: "AES.V2", key: Base.decode64!("...")}
       ]


### PR DESCRIPTION
I was upgrading an old project from v6 and ran into this. The example code uses `decode64` instead of `decode64!`, which returns an `{:ok, ...}` tuple and causes an error in the crypto library that had me scratching my head.

I realize it's a really old version at this point, but hopefully this will help someone out.