### PR TITLE
vault can be re-started

### DIFF
--- a/test/cloak/vault_test.exs
+++ b/test/cloak/vault_test.exs
@@ -49,11 +49,16 @@ defmodule Cloak.VaultTest do
       assert SupervisedVault.json_library() == Jason
       GenServer.stop(pid)
     end
+
+    test "can be re-started" do
+      {:ok, _} = RuntimeVault.start_link()
+      {:error, {:already_started, _}} = RuntimeVault.start_link()
+    end
   end
 
   describe ".init/1" do
     test "returns the given config" do
-      assert {:ok, []} == TestVault.init([])
+      assert {:ok, [], {:continue, :save_config}} == TestVault.init([])
     end
   end
 


### PR DESCRIPTION
Do not crash if vault is started more than once. 
Instead return `{:error, {:already_started, <pid>}}` so it can be handled by caller, which is proper OTP behavior I believe.