### PR TITLE
Raise helpful error if vault hasn't been started

### DIFF
--- a/lib/cloak/exceptions/vault_not_started.ex
+++ b/lib/cloak/exceptions/vault_not_started.ex
@@ -1,0 +1,50 @@
+defmodule Cloak.VaultNotStarted do
+  @moduledoc """
+  This exception indicates that your vault process hasn't been started yet. Before 
+  calling any vault functions, you must either:
+
+  #### 1. Call `start_link/0` on your vault module
+
+      MyApp.Vault.start_link()
+
+  #### 2. Ensure your application is started
+  If your vault module has been added to your application supervision tree, make
+  sure your application is running before calling any vault functions.
+
+      Application.ensure_all_started(:my_app)
+
+  """
+  defexception [:message, :vault]
+
+  @doc false
+  def exception(table_name) do
+    vault = infer_vault_name(table_name)
+
+    %__MODULE__{
+      message: """
+      #{vault}.Config ETS table was not found! 
+
+      This indicates that your vault process is not running. Ensure that it is 
+      running before calling this function.
+
+      The simplest way to do that is to call `start_link/0`:
+
+         #{vault}.start_link()
+
+      If your vault has been added to your application's supervision tree, 
+      ensure that your app has been started before calling any vault functions.
+
+         Application.ensure_all_started(:my_app)
+      """,
+      vault: vault
+    }
+  end
+
+  defp infer_vault_name(table_name) do
+    table_name
+    |> to_string()
+    |> String.replace(".Config", "")
+    |> String.replace("Elixir.", "")
+    |> String.to_atom()
+  end
+end

--- a/test/cloak/vault_test.exs
+++ b/test/cloak/vault_test.exs
@@ -87,6 +87,10 @@ defmodule Cloak.VaultTest do
 
       GenServer.stop(pid)
     end
+
+    test "returns helpful error if vault hasn't been started" do
+      assert {:error, %Cloak.VaultNotStarted{}} = RuntimeVault.encrypt("plaintext")
+    end
   end
 
   describe ".encrypt!/1" do
@@ -105,6 +109,12 @@ defmodule Cloak.VaultTest do
 
       GenServer.stop(pid)
     end
+
+    test "raises error if vault has not been started" do
+      assert_raise Cloak.VaultNotStarted, fn ->
+        RuntimeVault.encrypt!("plaintext")
+      end
+    end
   end
 
   describe ".encrypt/2" do
@@ -115,6 +125,10 @@ defmodule Cloak.VaultTest do
 
     test "returns error if no cipher associated with label" do
       assert {:error, %Cloak.MissingCipher{}} = TestVault.encrypt("plaintext", :nonexistent)
+    end
+
+    test "returns error if vault has not been started" do
+      assert {:error, %Cloak.VaultNotStarted{}} = RuntimeVault.encrypt("plaintext", :secondary)
     end
   end
 
@@ -130,6 +144,12 @@ defmodule Cloak.VaultTest do
         TestVault.encrypt!("plaintext", :nonexistent)
       end
     end
+
+    test "raises error if vault has not been started" do
+      assert_raise Cloak.VaultNotStarted, fn ->
+        RuntimeVault.encrypt!("plaintext", :secondary)
+      end
+    end
   end
 
   describe ".decrypt/1" do
@@ -143,6 +163,10 @@ defmodule Cloak.VaultTest do
 
     test "returns error if no module found to decrypt" do
       assert {:error, %Cloak.MissingCipher{}} = TestVault.decrypt(<<123, 123>>)
+    end
+
+    test "returns error if vault not started" do
+      assert {:error, %Cloak.VaultNotStarted{}} = RuntimeVault.decrypt(<<123, 123>>)
     end
   end
 
@@ -160,11 +184,21 @@ defmodule Cloak.VaultTest do
         TestVault.decrypt!(<<123, 123>>)
       end
     end
+
+    test "raises error if vault has not been started" do
+      assert_raise Cloak.VaultNotStarted, fn ->
+        RuntimeVault.decrypt!(<<123, 123>>)
+      end
+    end
   end
 
   describe ".json_library/1" do
     test "returns Jason by default" do
       assert TestVault.json_library() == Jason
+    end
+
+    test "returns error if vault has not been started" do
+      assert {:error, %Cloak.VaultNotStarted{}} = RuntimeVault.json_library()
     end
   end
 end


### PR DESCRIPTION
Fixes #125. The problem was that users weren't waiting for the vault process to start before calling functions on it in their `release.ex` file.
